### PR TITLE
ci: fix multi-version CI + add CodeQL code scanning

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,22 @@
+name: "TMI clients CodeQL config"
+
+# The bulk of this repo is openapi-generator output. Scanning it produces
+# low-signal noise we cannot fix without changing the generator, so we exclude
+# the generated client packages and only scan the hand-maintained code:
+#   - Python: the regeneration tooling (root *.py and python-client-generated/scripts/)
+#   - TypeScript: the hand-written tests + tooling config (test/, *.config.*)
+# (The Go client is 100% generated, so it is omitted from the CodeQL matrix
+#  entirely rather than ignored here — ignoring all of it would leave the Go
+#  analysis with no code to scan and fail the run.)
+#
+# The `*/` segment matches every version directory (v1.2.1, v1.4.0, ...), so new
+# client versions are covered automatically with no edits here.
+paths-ignore:
+  # Generated Python client packages
+  - python-client-generated/*/tmi_client
+  - python-client-generated/*/test
+  - python-client-generated/*/docs
+  # Generated TypeScript client sources and build output
+  - typescript-client-generated/*/src
+  - typescript-client-generated/*/dist
+  - typescript-client-generated/*/docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       versions: ${{ steps.matrix.outputs.versions }}
       go_versions: ${{ steps.matrix.outputs.go_versions }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - id: matrix
         run: |
           echo "versions=$(jq -c '[.versions[].version]' versions.json)" >> "$GITHUB_OUTPUT"
@@ -34,10 +34,10 @@ jobs:
       run:
         working-directory: python-client-generated/v${{ matrix.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: Run tests
         run: uv run --with pytest python3 -m pytest test/ -v --tb=short
@@ -53,9 +53,9 @@ jobs:
       run:
         working-directory: typescript-client-generated/v${{ matrix.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "20"
           cache: npm
@@ -81,9 +81,9 @@ jobs:
       run:
         working-directory: go-client-generated/v${{ matrix.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           # Build each module with the Go version declared in its own go.mod.
           go-version-file: go-client-generated/v${{ matrix.version }}/go.mod

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,54 +9,65 @@ on:
 jobs:
   test-python:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["v1.2.1", "v1.3.0", "v1.4.0"]
     defaults:
       run:
-        working-directory: python-client-generated
+        working-directory: python-client-generated/${{ matrix.version }}
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install dependencies
-        run: pip install -e ".[test]"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
 
       - name: Run tests
-        run: pytest test/ -v --tb=short
+        run: uv run --with pytest python3 -m pytest test/ -v --tb=short
 
   test-js:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["v1.2.1", "v1.3.0", "v1.4.0"]
     defaults:
       run:
-        working-directory: javascript-client-generated
+        working-directory: typescript-client-generated/${{ matrix.version }}
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
+          cache: npm
+          cache-dependency-path: typescript-client-generated/${{ matrix.version }}/package-lock.json
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Build
         run: npm run build
 
       - name: Run tests
-        run: npm test
+        run: npm run test --if-present
 
   test-go:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["v1_2_1", "v1_3_0", "v1_4_0"]
     defaults:
       run:
-        working-directory: go-client-generated
+        working-directory: go-client-generated/${{ matrix.version }}
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.23"
+          cache-dependency-path: go-client-generated/${{ matrix.version }}/go.sum
 
       - name: Build
         run: go build ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,15 +7,32 @@ on:
     branches: [main]
 
 jobs:
+  # Derive the version matrices from versions.json so adding/removing a client
+  # version there automatically updates CI with no edits to this file.
+  #   versions   -> dotted dirs for Python/TypeScript  (e.g. 1.4.0 -> v1.4.0)
+  #   go_versions-> underscored dirs for Go            (e.g. 1.4.0 -> v1_4_0)
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.matrix.outputs.versions }}
+      go_versions: ${{ steps.matrix.outputs.go_versions }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: matrix
+        run: |
+          echo "versions=$(jq -c '[.versions[].version]' versions.json)" >> "$GITHUB_OUTPUT"
+          echo "go_versions=$(jq -c '[.versions[].version | gsub("\\."; "_")]' versions.json)" >> "$GITHUB_OUTPUT"
+
   test-python:
+    needs: setup
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        version: ["v1.2.1", "v1.3.0", "v1.4.0"]
+        version: ${{ fromJSON(needs.setup.outputs.versions) }}
     defaults:
       run:
-        working-directory: python-client-generated/${{ matrix.version }}
+        working-directory: python-client-generated/v${{ matrix.version }}
     steps:
       - uses: actions/checkout@v4
 
@@ -26,14 +43,15 @@ jobs:
         run: uv run --with pytest python3 -m pytest test/ -v --tb=short
 
   test-js:
+    needs: setup
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        version: ["v1.2.1", "v1.3.0", "v1.4.0"]
+        version: ${{ fromJSON(needs.setup.outputs.versions) }}
     defaults:
       run:
-        working-directory: typescript-client-generated/${{ matrix.version }}
+        working-directory: typescript-client-generated/v${{ matrix.version }}
     steps:
       - uses: actions/checkout@v4
 
@@ -41,7 +59,7 @@ jobs:
         with:
           node-version: "20"
           cache: npm
-          cache-dependency-path: typescript-client-generated/${{ matrix.version }}/package-lock.json
+          cache-dependency-path: typescript-client-generated/v${{ matrix.version }}/package-lock.json
 
       - name: Install dependencies
         run: npm ci
@@ -53,21 +71,23 @@ jobs:
         run: npm run test --if-present
 
   test-go:
+    needs: setup
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        version: ["v1_2_1", "v1_3_0", "v1_4_0"]
+        version: ${{ fromJSON(needs.setup.outputs.go_versions) }}
     defaults:
       run:
-        working-directory: go-client-generated/${{ matrix.version }}
+        working-directory: go-client-generated/v${{ matrix.version }}
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
-          cache-dependency-path: go-client-generated/${{ matrix.version }}/go.sum
+          # Build each module with the Go version declared in its own go.mod.
+          go-version-file: go-client-generated/v${{ matrix.version }}/go.mod
+          cache-dependency-path: go-client-generated/v${{ matrix.version }}/go.sum
 
       - name: Build
         run: go build ./...

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,9 +22,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Go is intentionally omitted: the Go client is 100% generated, so it
+          # is excluded from scanning. See .github/codeql/codeql-config.yml.
           - language: python
-            build-mode: none
-          - language: go
             build-mode: none
           - language: javascript-typescript
             build-mode: none
@@ -37,6 +37,7 @@ jobs:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           queries: security-extended
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,10 +29,10 @@ jobs:
           - language: javascript-typescript
             build-mode: none
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@c35d1b164463ee62a100735382aaaa525c5d3496 # v3 (codeql-bundle-v2.25.6)
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -40,6 +40,6 @@ jobs:
           config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@c35d1b164463ee62a100735382aaaa525c5d3496 # v3 (codeql-bundle-v2.25.6)
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,44 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly full scan (Mondays 07:00 UTC) to catch newly published query updates.
+    - cron: "0 7 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: python
+            build-mode: none
+          - language: go
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/publish-go.yml
+++ b/.github/workflows/publish-go.yml
@@ -8,18 +8,32 @@ jobs:
   validate:
     if: startsWith(github.ref, 'refs/tags/go-v')
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: go-client-generated
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions/setup-go@v5
+      - name: Determine version directory
+        id: version
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#go-v}"
+          # Go version dirs use underscores (v1_4_0), not dots.
+          echo "go_dir=go-client-generated/v${TAG_VERSION//./_}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify version directory exists
+        run: |
+          if [ ! -d "${{ steps.version.outputs.go_dir }}" ]; then
+            echo "::error::Directory ${{ steps.version.outputs.go_dir }} does not exist"
+            exit 1
+          fi
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.21"
+          go-version-file: ${{ steps.version.outputs.go_dir }}/go.mod
+          cache-dependency-path: ${{ steps.version.outputs.go_dir }}/go.sum
 
       - name: Build
+        working-directory: ${{ steps.version.outputs.go_dir }}
         run: go build ./...
 
       - name: Test
+        working-directory: ${{ steps.version.outputs.go_dir }}
         run: go test -v ./...

--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -11,27 +11,43 @@ jobs:
     environment: npm
     permissions:
       id-token: write  # Required for npm provenance
-    defaults:
-      run:
-        working-directory: typescript-client-generated
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions/setup-node@v4
+      - name: Determine version directory
+        id: version
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#ts-v}"
+          echo "pkg_dir=typescript-client-generated/v${TAG_VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify version directory exists
+        run: |
+          if [ ! -d "${{ steps.version.outputs.pkg_dir }}" ]; then
+            echo "::error::Directory ${{ steps.version.outputs.pkg_dir }} does not exist"
+            exit 1
+          fi
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
+          cache: npm
+          cache-dependency-path: ${{ steps.version.outputs.pkg_dir }}/package-lock.json
 
       - name: Install dependencies
-        run: npm install
+        working-directory: ${{ steps.version.outputs.pkg_dir }}
+        run: npm ci
 
       - name: Build
+        working-directory: ${{ steps.version.outputs.pkg_dir }}
         run: npm run build
 
       - name: Run tests
-        run: npm test
+        working-directory: ${{ steps.version.outputs.pkg_dir }}
+        run: npm run test --if-present
 
       - name: Publish to npm
+        working-directory: ${{ steps.version.outputs.pkg_dir }}
         run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -9,9 +9,9 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/python-v')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 
@@ -57,7 +57,7 @@ jobs:
         run: python -m build
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: python-dist
           path: ${{ steps.version.outputs.pkg_dir }}/dist/
@@ -70,13 +70,13 @@ jobs:
       id-token: write
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: python-dist
           path: dist/
 
       - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           repository-url: https://test.pypi.org/legacy/
 
@@ -88,10 +88,10 @@ jobs:
       id-token: write
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: python-dist
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0


### PR DESCRIPTION
## Summary

The CI workflow targeted the old flat client layout and failed on every open PR. This reworks CI for the current multi-version layout and adds GitHub code scanning (CodeQL).

### Fixes the failing CI
The previous `ci.yml` broke because the repo moved to versioned subdirectories:
- `test-python` ran in `python-client-generated/` → *neither setup.py nor pyproject.toml found* (projects now live in `v1.2.1/`, `v1.3.0/`, `v1.4.0/`)
- `test-js` ran in `javascript-client-generated/` → *No such file or directory* (it's `typescript-client-generated/`)
- `test-go` ran `go build ./...` at the root → no `go.sum` (modules are in `v1_2_1/`, etc.)

Each job is now a version matrix pointing at the real directories:
- **Python** — `uv run --with pytest` per version
- **TypeScript** — `npm ci` + build, `npm run test --if-present` (only v1.4.0 ships tests)
- **Go** — build + test per module, each using the Go version from its own `go.mod`

### Future-proof
A `setup` job derives the matrices from `versions.json` (the same source of truth `regenerate_all.py` uses). Adding a version there updates all three jobs automatically — no edits to the workflow.

### CodeQL code scanning
New `codeql.yml` (python + javascript-typescript) with `.github/codeql/codeql-config.yml` that `paths-ignore`s the generated client packages, so scanning focuses on hand-maintained code (regeneration tooling + hand-written tests). The `*/` glob covers all version dirs automatically.

Go is intentionally omitted from CodeQL: that client is 100% generated, and ignoring all of it would leave the Go analysis with no code to scan.

## Verification
- Build/test commands confirmed passing locally across all versions (Python 469/502/588 tests; TS build + 12 tests; Go build + test).
- `jq` matrix derivation confirmed to emit the dotted and underscored arrays.
- All workflow/config YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)