### PR TITLE
ci: add Dependabot config for github-actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  # Keep the SHA-pinned actions in .github/workflows current. The repo
+  # enforces sha_pinning_required, so actions are pinned to commit SHAs;
+  # Dependabot bumps the SHA (and the trailing # version comment) for us.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      # Roll all action updates into a single PR to keep the noise down.
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds `.github/dependabot.yml` with a `github-actions` ecosystem entry (weekly, grouped into one PR).

The repo had no Dependabot config, so only **security** updates ran automatically — the earlier urllib3/vitest PRs. **Version** updates require a config. Since the repo enforces `sha_pinning_required` and all workflow actions are now pinned to commit SHAs, this lets Dependabot bump those SHAs (and their `# version` comments) automatically.

Scope is intentionally limited to github-actions. Security updates for pip/npm/go continue automatically as before; scheduled version updates for those can be added later if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)