### PR TITLE
deps: fix regen-script dependency drift (vitest ^3.2 -> ^4.1)

### DIFF
--- a/regenerate_ts.py
+++ b/regenerate_ts.py
@@ -64,7 +64,7 @@ PACKAGE_JSON = """\
     "eslint": "^10.0",
     "typescript": "^6.0",
     "typescript-eslint": "^8.60",
-    "vitest": "^3.2"
+    "vitest": "^4.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

`/deps:bump` scoped to **regen-script drift only** (the clients are auto-generated; `regenerate_*.py` owns the dependency versions, so bumping generated output is transient).

Audited the version pins in all three regeneration scripts:

| Script | Pins checked | Result |
|---|---|---|
| `regenerate_ts.py` | `@eslint/js ^10.0`, `eslint ^10.0`, `typescript ^6.0`, `typescript-eslint ^8.60`, `vitest ^3.2` | **vitest stale** (latest 4.1.8); rest current |
| `regenerate_python.py` | `urllib3 >=2.6.3` floor | current (resolves to 2.7.0) |
| `regenerate_go.py` | `GO_VERSION 1.23`, modules via `go mod tidy` | no pinned module versions |

**Fix:** `vitest ^3.2 → ^4.1` in `regenerate_ts.py`.

## Why this matters
Dependabot already bumped `v1.4.0` to vitest 4.1.0 (PR #12), and its `test-js (1.4.0)` job passed green. But the regen script still pinned `^3.2`, so the next regeneration would have silently downgraded vitest back to 3.x. This aligns the script with the already-verified 4.x.

## Verification
- `python3 -m py_compile regenerate_ts.py` passes.
- vitest 4.x is already confirmed working with the existing `vitest.config.ts` + tests via the merged Dependabot PR #12 (CI green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)