### PR TITLE
ci: add scheduled security-audit workflow + regen-drift checker

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,95 @@
+name: Security Audit
+
+# Proactive vulnerability + regen-drift sweep across every client version.
+# Dependabot covers security *updates*; this catches anything outstanding
+# between regenerations and fails (notifying the repo) when something is found.
+on:
+  schedule:
+    - cron: "0 8 * * 1" # Mondays 08:00 UTC (offset from the CodeQL scan)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  # Derive version matrices from versions.json (see ci.yml).
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.matrix.outputs.versions }}
+      go_versions: ${{ steps.matrix.outputs.go_versions }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - id: matrix
+        run: |
+          echo "versions=$(jq -c '[.versions[].version]' versions.json)" >> "$GITHUB_OUTPUT"
+          echo "go_versions=$(jq -c '[.versions[].version | gsub("\\."; "_")]' versions.json)" >> "$GITHUB_OUTPUT"
+
+  audit-python:
+    needs: setup
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ${{ fromJSON(needs.setup.outputs.versions) }}
+    defaults:
+      run:
+        working-directory: python-client-generated/v${{ matrix.version }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      - name: pip-audit
+        # Environment mode: uv's standalone Python ships without pip, so
+        # pip-audit's default `-r` venv builder fails. Audit the installed
+        # dists instead.
+        run: uv run --with pip-audit --with-requirements requirements.txt pip-audit
+
+  audit-node:
+    needs: setup
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ${{ fromJSON(needs.setup.outputs.versions) }}
+    defaults:
+      run:
+        working-directory: typescript-client-generated/v${{ matrix.version }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: typescript-client-generated/v${{ matrix.version }}/package-lock.json
+      - run: npm ci
+      - name: npm audit
+        # Report everything, then gate the job on high/critical findings.
+        run: |
+          npm audit || true
+          npm audit --audit-level=high
+
+  audit-go:
+    needs: setup
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ${{ fromJSON(needs.setup.outputs.go_versions) }}
+    defaults:
+      run:
+        working-directory: go-client-generated/v${{ matrix.version }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go-client-generated/v${{ matrix.version }}/go.mod
+          cache-dependency-path: go-client-generated/v${{ matrix.version }}/go.sum
+      - name: govulncheck
+        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+
+  regen-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Check regen-script dependency pins for major drift
+        run: python3 check_regen_drift.py

--- a/check_regen_drift.py
+++ b/check_regen_drift.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.9"
+# dependencies = []
+# ///
+"""Detect dependency-version drift in the regeneration scripts.
+
+The clients are auto-generated, so the regenerate_*.py scripts -- not the
+generated output -- own the dependency versions. This checker flags when a
+script's pin has fallen a major version behind the latest published release,
+which is the case a caret range (^MAJOR.MINOR) cannot absorb on its own.
+
+Currently scoped to the npm dev-dependency pins in regenerate_ts.py (the only
+script that pins caret ranges; regenerate_python.py uses floors and
+regenerate_go.py resolves modules via `go mod tidy`).
+
+Exit code 0 = no drift, 1 = drift found, 2 = checker error.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent
+TS_SCRIPT = REPO_ROOT / "regenerate_ts.py"
+
+# Matches lines like:   "vitest": "^4.1",   or   "@eslint/js": "^10.0"
+PIN_RE = re.compile(r'"(?P<name>@?[\w./-]+)":\s*"\^?(?P<major>\d+)\.\d+')
+
+
+def latest_major(pkg: str) -> int:
+    """Return the latest published major version for an npm package."""
+    # Scoped names (@scope/name) must have the slash percent-encoded.
+    encoded = pkg.replace("/", "%2F")
+    url = f"https://registry.npmjs.org/{encoded}/latest"
+    with urllib.request.urlopen(url, timeout=30) as resp:
+        data = json.load(resp)
+    return int(data["version"].split(".", 1)[0])
+
+
+def extract_dev_pins(text: str) -> dict[str, int]:
+    """Pull the devDependencies block out of regenerate_ts.py and parse pins."""
+    block = re.search(r'"devDependencies":\s*\{(.*?)\}', text, re.DOTALL)
+    if not block:
+        raise RuntimeError("could not locate devDependencies block in regenerate_ts.py")
+    return {m["name"]: int(m["major"]) for m in PIN_RE.finditer(block.group(1))}
+
+
+def main() -> int:
+    if not TS_SCRIPT.exists():
+        print(f"error: {TS_SCRIPT} not found", file=sys.stderr)
+        return 2
+
+    try:
+        pins = extract_dev_pins(TS_SCRIPT.read_text())
+    except RuntimeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    if not pins:
+        print("error: no dev-dependency pins parsed from regenerate_ts.py", file=sys.stderr)
+        return 2
+
+    drift = []
+    for pkg, pinned in sorted(pins.items()):
+        try:
+            current = latest_major(pkg)
+        except (urllib.error.URLError, KeyError, ValueError) as exc:
+            print(f"warning: could not check {pkg}: {exc}", file=sys.stderr)
+            continue
+        status = "DRIFT" if current > pinned else "ok"
+        print(f"  {pkg:<20} pinned ^{pinned}.x  latest {current}.x  [{status}]")
+        if current > pinned:
+            drift.append((pkg, pinned, current))
+
+    if drift:
+        print("\nregenerate_ts.py is a major version behind on:", file=sys.stderr)
+        for pkg, pinned, current in drift:
+            print(f"  - {pkg}: pinned ^{pinned}.x, latest {current}.x", file=sys.stderr)
+        return 1
+
+    print("\nNo regen-script dependency drift.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds a **Security Audit** workflow (`.github/workflows/security-audit.yml`) — weekly (Mondays 08:00 UTC) plus `workflow_dispatch` — that proactively sweeps every client version for known vulnerabilities and **fails the job** (which notifies the repo) when anything is found. Dependabot handles security *updates*; this catches anything outstanding between regenerations.

Jobs (matrices derived from `versions.json`, actions SHA-pinned):
- **Python** — `pip-audit` via uv environment mode. uv's standalone Python ships without `pip`, so pip-audit's default `-r` venv builder fails; environment mode audits the installed dists instead.
- **Node/TS** — `npm audit`, reported in full and gated on **high/critical**.
- **Go** — `govulncheck` via `go run golang.org/x/vuln/cmd/govulncheck@latest`.
- **regen-drift** — `check_regen_drift.py` flags when a `regenerate_ts.py` caret pin has fallen a major version behind the latest npm release (the vitest `^3.2` → `^4.x` case we just fixed). Queries the npm registry over stdlib HTTP — no npm needed.

## Why a workflow instead of adding client ecosystems to Dependabot
The clients are generated; Dependabot version-update PRs against the generated dirs are transient (overwritten on regen) and the durable pins live in `regenerate_*.py`, which Dependabot can't edit. A scheduled audit gives proactive coverage without that churn. (Dependabot security updates still run automatically and remain the update mechanism.)

## Verification
- `check_regen_drift.py` runs locally: all pins current, exit 0.
- Baseline local sweep across all 9 directories is clean (pip-audit / npm audit / govulncheck all report no vulnerabilities).
- `py_compile` + YAML validation pass; all actions SHA-pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)