### PR TITLE
ci: run govulncheck on a current Go toolchain

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -82,7 +82,11 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version-file: go-client-generated/v${{ matrix.version }}/go.mod
+          # Use a current Go toolchain rather than each module's older go.mod
+          # version: govulncheck@latest needs Go >= 1.25, and auditing against
+          # the current stdlib is what we want. The modules build fine under a
+          # newer Go (it is backward compatible).
+          go-version: "stable"
           cache-dependency-path: go-client-generated/v${{ matrix.version }}/go.sum
       - name: govulncheck
         run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...


### PR DESCRIPTION
Fixes the `audit-go` jobs in the Security Audit workflow.

`govulncheck@latest` (golang.org/x/vuln v1.3.0) requires Go >= 1.25, but the job used `go-version-file` (each module's declared Go, 1.21/1.23) with `GOTOOLCHAIN=local`, so `go run govulncheck@latest` refused to run:

```
golang.org/x/vuln@v1.3.0 requires go >= 1.25.0 (running go 1.23.12; GOTOOLCHAIN=local)
```

Switch the audit job to `go-version: "stable"`. The modules build fine under a newer Go (backward compatible), and analyzing against the current stdlib is the intended audit behavior. The Python/Node/regen-drift jobs already passed; this was the only failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)