### PR TITLE
ci: suppress no-tests failures for any client version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,17 @@ jobs:
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: Run tests
-        run: uv run --with pytest python3 -m pytest test/ -v --tb=short
+        # pytest exit code 5 means "no tests collected" — treat that as success
+        # so a version with an empty test/ dir doesn't fail CI. Real test
+        # failures (exit 1) still fail.
+        run: |
+          code=0
+          uv run --with pytest python3 -m pytest test/ -v --tb=short || code=$?
+          if [ "$code" -eq 5 ]; then
+            echo "pytest collected no tests (exit 5) — treating as success"
+            exit 0
+          fi
+          exit "$code"
 
   test-js:
     needs: setup
@@ -68,7 +78,9 @@ jobs:
         run: npm run build
 
       - name: Run tests
-        run: npm run test --if-present
+        # --if-present skips versions with no "test" script; --passWithNoTests
+        # keeps vitest from failing a version whose test script finds no tests.
+        run: npm run test --if-present -- --passWithNoTests
 
   test-go:
     needs: setup

--- a/typescript-client-generated/v1.3.0/package.json
+++ b/typescript-client-generated/v1.3.0/package.json
@@ -13,7 +13,6 @@
   "scripts": {
     "build": "tsc && tsc -p tsconfig.esm.json",
     "prepare": "npm run build",
-    "test": "vitest run",
     "test:watch": "vitest",
     "lint": "eslint test"
   },


### PR DESCRIPTION
## Summary
Stops a client version that has no test files from failing CI, for any language/version — generically in `ci.yml` plus removing the one stray script that triggered it.

## Changes
- **typescript-client-generated/v1.3.0/package.json**: remove the `test` script (`vitest run`). With no `test` script, `npm run test --if-present` skips this version (matches v1.2.1).
- **ci.yml `test-js`**: `npm run test --if-present -- --passWithNoTests` — any version that *does* have a vitest test script but no test files now passes instead of exiting 1.
- **ci.yml `test-python`**: treat pytest exit code 5 ("no tests collected") as success; real test failures (exit 1) still fail.
- **Go**: no change needed — `go test ./...` already exits 0 with no test files.

## Verification
- `package.json` parses as valid JSON; `ci.yml` parses as valid YAML.
- The pytest exit-code logic was simulated under `bash -eo pipefail`: exit 0 → pass, exit 1 → fail, exit 5 → pass.

## Note
The v1.3.0 `package.json` edit lives in generated output and would be re-added on regeneration, but the `ci.yml` changes are the durable, version-agnostic safety net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kt4c1Ah9Fwf6xpCQThxFyD