### PR TITLE
ci: suppress no-tests failures in publish workflows

### DIFF
--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -44,7 +44,9 @@ jobs:
 
       - name: Run tests
         working-directory: ${{ steps.version.outputs.pkg_dir }}
-        run: npm run test --if-present
+        # --if-present skips versions with no "test" script; --passWithNoTests
+        # keeps vitest from failing a version whose test script finds no tests.
+        run: npm run test --if-present -- --passWithNoTests
 
       - name: Publish to npm
         working-directory: ${{ steps.version.outputs.pkg_dir }}

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -48,9 +48,18 @@ jobs:
 
       - name: Run tests
         working-directory: ${{ steps.version.outputs.pkg_dir }}
+        # pytest exit code 5 means "no tests collected" — treat that as success
+        # so a version with an empty test/ dir doesn't fail. Real test failures
+        # (exit 1) still fail.
         run: |
           pip install pytest
-          pytest test/ -v --tb=short
+          code=0
+          pytest test/ -v --tb=short || code=$?
+          if [ "$code" -eq 5 ]; then
+            echo "pytest collected no tests (exit 5) — treating as success"
+            exit 0
+          fi
+          exit "$code"
 
       - name: Build package
         working-directory: ${{ steps.version.outputs.pkg_dir }}


### PR DESCRIPTION
## Summary
Follow-up to #20. Applies the same no-tests handling to the publish workflows so a client version with no test files doesn't fail a release.

## Changes
- **publish-js.yml**: `npm run test --if-present -- --passWithNoTests`.
- **publish-python.yml**: treat pytest exit code 5 ("no tests collected") as success; real test failures (exit 1) still fail.

These only run on release publish (`ts-v*` / python tags), but mirror the CI behavior for consistency.

## Verification
- Both workflow files parse as valid YAML.
- The pytest exit-code logic is identical to #20, which was simulated under `bash -eo pipefail` (0→pass, 1→fail, 5→pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kt4c1Ah9Fwf6xpCQThxFyD