### PR TITLE
Fix spurious warnings during client regeneration

### DIFF
--- a/regen_common.py
+++ b/regen_common.py
@@ -349,8 +349,14 @@ def patch_file_regex(
     pattern: str,
     replacement: str,
     description: str = "",
+    flags: int = re.MULTILINE,
 ) -> bool:
     """Apply a regex substitution to *file_path*.
+
+    Patterns are matched with ``re.MULTILINE`` by default so that ``^``/``$``
+    anchor to lines rather than to the whole file — patterns like
+    ``^version = ".*"`` target a single line in a config file, which is the
+    common case here. Pass ``flags=0`` for whole-file anchoring.
 
     Returns ``True`` if at least one replacement was made.
     """
@@ -363,7 +369,7 @@ def patch_file_regex(
         return False
 
     text = file_path.read_text(encoding="utf-8")
-    new_text, count = re.subn(pattern, replacement, text)
+    new_text, count = re.subn(pattern, replacement, text, flags=flags)
 
     if count == 0:
         print_warning(
@@ -387,22 +393,30 @@ def backup_files(
     files: list[str | Path],
     dirs: list[str | Path],
     backup_dir: str | Path,
-) -> None:
+) -> set[str]:
     """Copy *files* and *dirs* into *backup_dir*, preserving relative names.
 
-    Missing source items are silently skipped.
+    Source items that do not exist are skipped — that is the normal case when
+    generating a version directory for the first time, so it is reported as
+    information rather than as a warning.
+
+    Returns the set of names actually copied into *backup_dir*. Pass it to
+    :func:`restore_files` as ``backed_up`` so the restore step can tell
+    "never existed" apart from "was backed up and then went missing".
     """
     backup_dir = Path(backup_dir)
     backup_dir.mkdir(parents=True, exist_ok=True)
+    backed_up: set[str] = set()
 
     for f in files:
         src = Path(f)
         if src.is_file():
             dest = backup_dir / src.name
             shutil.copy2(src, dest)
+            backed_up.add(src.name)
             print_success(f"Backed up {src.name}")
         else:
-            print_warning(f"Skipping missing file: {src}")
+            print(f"  Nothing to back up (not present): {src.name}")
 
     for d in dirs:
         src = Path(d)
@@ -411,9 +425,12 @@ def backup_files(
             if dest.exists():
                 shutil.rmtree(dest)
             shutil.copytree(src, dest)
+            backed_up.add(src.name)
             print_success(f"Backed up directory {src.name}/")
         else:
-            print_warning(f"Skipping missing directory: {src}")
+            print(f"  Nothing to back up (not present): {src.name}/")
+
+    return backed_up
 
 
 def restore_files(
@@ -421,10 +438,14 @@ def restore_files(
     dest_dir: str | Path,
     files: list[str],
     dirs: list[str],
+    backed_up: set[str] | None = None,
 ) -> None:
     """Restore *files* and *dirs* from *backup_dir* into *dest_dir*.
 
-    Missing backup items trigger a warning rather than an error.
+    When *backed_up* is given (the return value of :func:`backup_files`), items
+    that were never backed up are skipped silently — there is nothing to
+    restore and nothing is wrong. An item that *was* backed up but is missing
+    from *backup_dir* is a real anomaly and still warns.
     """
     backup_dir = Path(backup_dir)
     dest_dir = Path(dest_dir)
@@ -435,6 +456,8 @@ def restore_files(
         if src.is_file():
             shutil.copy2(src, dest_dir / f)
             print_success(f"Restored {f}")
+        elif backed_up is not None and f not in backed_up:
+            continue  # never existed before regeneration; nothing to restore
         else:
             print_warning(f"Backup file not found, skipping: {src}")
 
@@ -446,6 +469,8 @@ def restore_files(
                 shutil.rmtree(dest)
             shutil.copytree(src, dest)
             print_success(f"Restored directory {d}/")
+        elif backed_up is not None and d not in backed_up:
+            continue  # never existed before regeneration; nothing to restore
         else:
             print_warning(f"Backup directory not found, skipping: {src}")
 

--- a/regenerate_go.py
+++ b/regenerate_go.py
@@ -258,7 +258,7 @@ def main(spec_path: str, output_dir: str | None = None) -> int:
     # 5. Backup
     print_step(3, "Backing up custom files")
     test_files = list(client_dir.glob("*_test.go"))
-    backup_files(
+    backed_up = backup_files(
         files=[
             client_dir / "go.mod",
             client_dir / "go.sum",
@@ -332,6 +332,7 @@ def main(spec_path: str, output_dir: str | None = None) -> int:
         dest_dir=client_dir,
         files=[".openapi-generator-ignore", *test_names],
         dirs=["developer"],
+        backed_up=backed_up,
     )
     # Fix developer docs path (backup stores as "developer/", need it at "docs/developer/")
     restored_dev = client_dir / "developer"

--- a/regenerate_python.py
+++ b/regenerate_python.py
@@ -458,7 +458,7 @@ def main(spec_path: str, output_dir: str | None = None) -> int:
 
     # 4. Backup
     print_step(3, "Backing up custom files")
-    backup_files(
+    backed_up = backup_files(
         files=[
             client_dir / "test_diagram_fixes.py",
             client_dir / ".openapi-generator-ignore",
@@ -515,7 +515,7 @@ def main(spec_path: str, output_dir: str | None = None) -> int:
     )
 
     # 7. Apply patches
-    print_step(6, "Applying patches")
+    print_step(7, "Applying patches")
     had_issues = patch_regex_validators(client_dir, had_issues)
     had_issues = patch_test_return_types(client_dir, had_issues)
     had_issues = patch_urllib3_minimum_version(client_dir, had_issues)
@@ -530,18 +530,19 @@ def main(spec_path: str, output_dir: str | None = None) -> int:
     print_success("Wrote ty.toml")
 
     # 8. Restore custom files
-    print_step(7, "Restoring custom files")
+    print_step(8, "Restoring custom files")
     restore_files(
         backup_dir=backup_dir,
         dest_dir=client_dir,
         files=["test_diagram_fixes.py", ".openapi-generator-ignore"],
         dirs=[],
+        backed_up=backed_up,
     )
     # Note: we do NOT restore pyproject.toml — openapi-generator produces
     # a good one with pydantic deps that we want to keep.
 
     # 9. Install deps
-    print_step(8, "Installing dependencies")
+    print_step(9, "Installing dependencies")
     result = run_command(
         ["uv", "pip", "install", "-e", ".", "--quiet"],
         cwd=client_dir,
@@ -552,7 +553,7 @@ def main(spec_path: str, output_dir: str | None = None) -> int:
         had_issues = True
 
     # 10. Run tests
-    print_step(9, "Running tests")
+    print_step(10, "Running tests")
     result = run_command(
         ["uv", "run", "--with", "pytest", "python3", "-m", "pytest", "test/", "-v", "--tb=short"],
         cwd=client_dir,
@@ -585,7 +586,7 @@ def main(spec_path: str, output_dir: str | None = None) -> int:
         print_warning("Integration test file not found")
 
     # 11. Generate report
-    print_step(10, "Generating summary report")
+    print_step(11, "Generating summary report")
     api_count = count_files(client_dir / "tmi_client" / "api", "*.py")
     model_count = count_files(client_dir / "tmi_client" / "models", "*.py")
     test_count = count_files(client_dir / "test", "*.py")
@@ -637,7 +638,7 @@ def main(spec_path: str, output_dir: str | None = None) -> int:
     print_success("Summary report generated: REGENERATION_REPORT.md")
 
     # 12. Cleanup
-    print_step(11, "Cleaning up")
+    print_step(12, "Cleaning up")
     clean_paths([backup_dir])
     print_success("Cleanup complete")
 

--- a/regenerate_ts.py
+++ b/regenerate_ts.py
@@ -332,7 +332,7 @@ def main(spec_path: str, output_dir: str | None = None) -> int:
 
     # 5. Backup
     print_step(3, "Backing up custom files")
-    backup_files(
+    backed_up = backup_files(
         files=[
             client_dir / ".openapi-generator-ignore",
         ],
@@ -395,6 +395,7 @@ def main(spec_path: str, output_dir: str | None = None) -> int:
         dest_dir=client_dir,
         files=[".openapi-generator-ignore"],
         dirs=["developer", "test"],
+        backed_up=backed_up,
     )
     # Fix developer docs path (restore puts it at client_dir/developer/)
     restored_dev = client_dir / "developer"


### PR DESCRIPTION
Fixes the two warnings that appeared in every regeneration run.

## 1. Version stamping silently did nothing

`patch_file_regex` called `re.subn` without `re.MULTILINE`, so `^version = ".*"` and `^VERSION = ".*"` could only match at the *start of the file*. The version sits on line 3 of `pyproject.toml` and line 23 of `setup.py`, so both patches reported `No matches for pattern` and left the files untouched:

```
⚠ No matches for pattern in .../v1.8.1/pyproject.toml (pyproject.toml version)
⚠ No matches for pattern in .../v1.8.1/setup.py (setup.py version)
```

Runs still produced a correct version only because `update_json_version` stamps `packageVersion` into the codegen config before generation — the step intended as a safety net was dead code.

`patch_file_regex` now defaults to `re.MULTILINE`, with a `flags` parameter to opt out. The two `go.mod` patterns are unaffected (neither uses `^` or `$`), verified below.

## 2. Restore warned about files that were never backed up

On a fresh version directory there is nothing to back up, so `restore_files` reported:

```
⚠ Backup file not found, skipping: .../.regeneration_backup/test_diagram_fixes.py
⚠ Backup file not found, skipping: .../.regeneration_backup/.openapi-generator-ignore
```

duplicating what the backup step had already noted. `backup_files` now returns the set of names it actually copied; `restore_files` accepts it as `backed_up` and skips those items silently. A file that *was* backed up and then went missing is a genuine anomaly and still warns. Omitting `backed_up` preserves the previous behavior.

Wired through all three language scripts.

## Also

The Python script had two `print_step(6, ...)` calls, mislabeling every step after it. Renumbered 6–12.

## Verification

No unit tests exist for these scripts, so the changed functions were exercised directly — 15 checks, all passing, including running the version patterns against the real committed `v1.8.1/pyproject.toml` and `setup.py`:

- version stamping now matches in both files, with no warning, and changes only the version line
- `go.mod` module-path and Go-version patterns still patch correctly (no MULTILINE regression)
- `backup_files` returns only items that exist; emits no warning for absent sources
- `restore_files` restores backed-up files and stays silent about never-backed-up ones
- a backed-up-then-deleted file **still warns** (the fix does not over-suppress)
- calls omitting `backed_up` retain the old warning behavior

`ruff check` reports the same 8 pre-existing findings before and after this change (shebang/exec-bit, `subprocess.run` without `check`, `datetime.now()` without tz, one `B023`) — none in the touched lines, and none newly introduced. All files compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116ox2SywZRuZ46c8VEWDHh