### PR TITLE
Bump regenerate_ts.py to TypeScript 7 and modernize module resolution

### DIFF
--- a/regenerate_ts.py
+++ b/regenerate_ts.py
@@ -62,7 +62,7 @@ PACKAGE_JSON = """\
   "devDependencies": {
     "@eslint/js": "^10.0",
     "eslint": "^10.0",
-    "typescript": "^6.0",
+    "typescript": "^7.0",
     "typescript-eslint": "^8.60",
     "vitest": "^4.1"
   },
@@ -85,9 +85,8 @@ TSCONFIG = """\
   "compilerOptions": {
     "declaration": true,
     "target": "ES2022",
-    "module": "commonjs",
-    "moduleResolution": "node10",
-    "ignoreDeprecations": "6.0",
+    "module": "node16",
+    "moduleResolution": "node16",
     "rootDir": "./src",
     "outDir": "dist",
     "typeRoots": [
@@ -109,6 +108,7 @@ TSCONFIG_ESM = """\
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "esnext",
+    "moduleResolution": "bundler",
     "outDir": "dist/esm"
   }
 }


### PR DESCRIPTION
Fixes the `regen-drift` check that has failed on **every scheduled `security-audit` run since 2026-07-13** (last success 2026-07-06). It went unnoticed because that job runs weekly and doesn't gate PRs.

`regenerate_ts.py` pinned `typescript ^6.0`; 7.x is published.

## Why the pin bump alone isn't enough

TypeScript 7 **removes** `moduleResolution: node10`, which the tsconfig template used:

```
tsconfig.json(6,25): error TS5108: Option 'moduleResolution=node10' has been removed.
```

Fixing that cascades — `node16` resolution requires `module` to agree, and the ESM config then inherits `node16` and conflicts with its own `module: esnext`. The full set:

| File | Change |
|---|---|
| package.json template | `typescript` `^6.0` → `^7.0` |
| `tsconfig.json` | `module` `commonjs` → `node16` |
| `tsconfig.json` | `moduleResolution` `node10` → `node16` |
| `tsconfig.json` | drop `ignoreDeprecations: "6.0"` (existed only to silence the node10 deprecation; now dead config) |
| `tsconfig.esm.json` | add `moduleResolution: bundler` |

## Consumer-visible change

`node10` → `node16` changes how the published `@tmiclient/client` resolves imports. Consumers on older bundlers or Node versions relying on node10 semantics may be affected. Deliberate, and approved before implementing.

## Verification

Wrote the templates this script emits into a copy of the generated v1.8.1 client and built it:

- `tsc --version` → **7.0.2**
- `npm run build` → **exit 0**
- CJS output emits `"use strict"`; ESM output emits `export * from './runtime'` — both correct for their target
- `check_regen_drift.py` → **"No regen-script dependency drift"** across all five pinned packages (was failing on typescript)
- `ruff check` clean; file compiles; both templates parse as valid JSON

## Scope

This changes only what **future regenerations** produce. The committed client directories keep their existing tsconfig and `typescript ^6.0` until regenerated, so CI — which builds those directories as committed — is unaffected. Expect the TS 7 toolchain to actually land in the clients at the next `regenerate_all.py` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116ox2SywZRuZ46c8VEWDHh