### PR TITLE
chore: ignore HANDOFF.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ python-client-generated/.openapi-generator/
 .pypirc
 REGENERATION_REPORT.md
 REGENERATION_PLAN.md
+HANDOFF.md


### PR DESCRIPTION
Adds `HANDOFF.md` to `.gitignore`.

It's a local working note used to carry context between sessions — the same category as the already-ignored `REGENERATION_REPORT.md` and `REGENERATION_PLAN.md`, so it slots in beside them. Ignoring it keeps it out of `git status` and safe from an accidental `git add -A`.

One line; no code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116ox2SywZRuZ46c8VEWDHh