### PR TITLE
ci: add publish dry runs and alert on silent security-audit failures

### DIFF
--- a/.github/workflows/publish-go.yml
+++ b/.github/workflows/publish-go.yml
@@ -3,18 +3,40 @@ name: Validate Go Client
 on:
   release:
     types: [published]
+  # Manual dry run. This workflow only builds and tests — it never publishes —
+  # so a dispatch is equivalent to the release path.
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Client version to validate, e.g. 1.8.3 (dotted, not underscored)"
+        required: true
+        type: string
 
 jobs:
   validate:
-    if: startsWith(github.ref, 'refs/tags/go-v')
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/go-v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Determine version directory
         id: version
+        # Both sources are untrusted-ish (a dispatch input, a tag name), and the
+        # result becomes a filesystem path, so pass them through env: rather than
+        # ${{ }} interpolation and reject anything that is not a bare N.N.N.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          TAG_VERSION="${GITHUB_REF_NAME#go-v}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            TAG_VERSION="$INPUT_VERSION"
+          else
+            TAG_VERSION="${GITHUB_REF_NAME#go-v}"
+          fi
+          if ! printf '%s' "$TAG_VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Invalid version '$TAG_VERSION' (expected N.N.N)"
+            exit 1
+          fi
           # Go version dirs use underscores (v1_4_0), not dots.
           echo "go_dir=go-client-generated/v${TAG_VERSION//./_}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -3,10 +3,18 @@ name: Publish JavaScript Client to npm
 on:
   release:
     types: [published]
+  # Manual dry run: installs, builds and tests a committed client version. The
+  # publish step below stays gated on `release`, so a dispatch never publishes.
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Client version directory to build, e.g. 1.8.3 (dry run — does not publish)"
+        required: true
+        type: string
 
 jobs:
   publish:
-    if: startsWith(github.ref, 'refs/tags/ts-v')
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/ts-v')
     runs-on: ubuntu-latest
     environment: npm
     permissions:
@@ -16,8 +24,22 @@ jobs:
 
       - name: Determine version directory
         id: version
+        # Both sources are untrusted-ish (a dispatch input, a tag name), and the
+        # result becomes a filesystem path, so pass them through env: rather than
+        # ${{ }} interpolation and reject anything that is not a bare N.N.N.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          TAG_VERSION="${GITHUB_REF_NAME#ts-v}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            TAG_VERSION="$INPUT_VERSION"
+          else
+            TAG_VERSION="${GITHUB_REF_NAME#ts-v}"
+          fi
+          if ! printf '%s' "$TAG_VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Invalid version '$TAG_VERSION' (expected N.N.N)"
+            exit 1
+          fi
           echo "pkg_dir=typescript-client-generated/v${TAG_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Verify version directory exists
@@ -49,6 +71,8 @@ jobs:
         run: npm run test --if-present -- --passWithNoTests
 
       - name: Publish to npm
+        # Never publish from a manual dry run.
+        if: github.event_name == 'release'
         working-directory: ${{ steps.version.outputs.pkg_dir }}
         run: npm publish --provenance --access public
         env:

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -3,10 +3,19 @@ name: Publish Python Client
 on:
   release:
     types: [published]
+  # Manual dry run: builds and tests a committed client version without
+  # publishing anything, so action-version bumps in this file can be validated
+  # without cutting a release. The publish jobs below stay gated on `release`.
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Client version directory to build, e.g. 1.8.3 (dry run — does not publish)"
+        required: true
+        type: string
 
 jobs:
   build-and-test:
-    if: startsWith(github.ref, 'refs/tags/python-v')
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/python-v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -17,8 +26,22 @@ jobs:
 
       - name: Determine version directory
         id: version
+        # Both sources are untrusted-ish (a dispatch input, a tag name), and the
+        # result becomes a filesystem path, so pass them through env: rather than
+        # ${{ }} interpolation and reject anything that is not a bare N.N.N.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          TAG_VERSION="${GITHUB_REF_NAME#python-v}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            TAG_VERSION="$INPUT_VERSION"
+          else
+            TAG_VERSION="${GITHUB_REF_NAME#python-v}"
+          fi
+          if ! printf '%s' "$TAG_VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Invalid version '$TAG_VERSION' (expected N.N.N)"
+            exit 1
+          fi
           echo "tag_version=$TAG_VERSION" >> "$GITHUB_OUTPUT"
           echo "pkg_dir=python-client-generated/v${TAG_VERSION}" >> "$GITHUB_OUTPUT"
 
@@ -73,6 +96,8 @@ jobs:
 
   publish-testpypi:
     needs: build-and-test
+    # Never publish from a manual dry run.
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     environment: testpypi
     permissions:
@@ -91,6 +116,7 @@ jobs:
 
   publish-pypi:
     needs: publish-testpypi
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     environment: pypi
     permissions:

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -103,3 +103,46 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Check regen-script dependency pins for major drift
         run: python3 check_regen_drift.py
+
+  # This workflow is scheduled and does not gate PRs, so a failure is otherwise
+  # silent — it went unnoticed for three weeks in July 2026. File (or comment on)
+  # a tracking issue instead, so a failing audit surfaces in normal repo traffic.
+  notify-on-failure:
+    # `setup` is listed explicitly: if it fails the audit jobs are *skipped*
+    # rather than failed, and the alert must still fire.
+    needs: [setup, audit-python, audit-node, audit-go, regen-drift]
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Open or update the audit-failure issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          TITLE="Security audit failed"
+          LABEL="security-audit"
+
+          # Idempotent: the label may not exist yet on a fresh repo.
+          gh label create "$LABEL" --repo "$REPO" \
+            --color B60205 --description "Automated security-audit failures" \
+            2>/dev/null || true
+
+          BODY=$(printf '%s\n\n%s\n' \
+            "The scheduled \`Security Audit\` workflow failed. It does not gate pull requests, so this issue is the only notification." \
+            "Failing run: $RUN_URL")
+
+          EXISTING=$(gh issue list --repo "$REPO" --state open --label "$LABEL" \
+            --json number,title \
+            --jq "map(select(.title == \"$TITLE\")) | .[0].number // empty")
+
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --repo "$REPO" --body "$BODY"
+            echo "Commented on existing issue #$EXISTING"
+          else
+            gh issue create --repo "$REPO" --title "$TITLE" \
+              --label "$LABEL" --body "$BODY"
+          fi


### PR DESCRIPTION
Closes two CI blind spots carried over from the last session.

## 1. Publish workflows can now be dry-run (`workflow_dispatch`)

The GitHub Actions majors bumped in #29 — `setup-python` v7 and `gh-action-pypi-publish` v1.14.2 — have never executed, because the three `publish-*.yml` workflows trigger only on `release: published`. The first execution would have been a real Python client publish.

All three now also accept `workflow_dispatch` with a `version` input:

| Workflow | Dispatch runs | Dispatch skips |
|---|---|---|
| `publish-python.yml` | checkout, setup-python v7, build, tests, `python -m build`, upload-artifact | `publish-testpypi`, `publish-pypi` |
| `publish-js.yml` | checkout, setup-node, `npm ci`, build, tests | `npm publish` |
| `publish-go.yml` | everything (validate-only workflow, nothing to skip) | — |

Publishing steps are gated on `github.event_name == 'release'`, so a dispatch can never publish.

**Caveat:** `gh-action-pypi-publish` still cannot be exercised this way — proving that one requires a real upload. The dispatch validates everything up to it.

### Input handling

The dispatch input and the tag name both become a filesystem path, so they are passed via `env:` rather than `${{ }}` interpolation and rejected unless they match `^[0-9]+\.[0-9]+\.[0-9]+$`. This also hardens the pre-existing tag-derived path.

## 2. `security-audit` failures are no longer silent

`security-audit.yml` runs weekly and gates nothing, so it failed every run from 2026-07-13 through 2026-08-03 without anyone noticing — found only by dispatching it manually.

A `notify-on-failure` job now opens a labelled tracking issue on failure, or comments on the existing one so repeated failures do not spam. It creates the `security-audit` label idempotently, and depends on `setup` explicitly because a `setup` failure leaves the audit jobs *skipped* rather than failed.

## Verification

- `actionlint` clean on all four changed files (the only findings repo-wide are two pre-existing info-level SC2012 notices in the unchanged matrix-derivation blocks of `ci.yml` and `security-audit.yml`).
- YAML parses for all six workflows.

The dispatch paths and the failure alert are both exercised only once this is on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116ox2SywZRuZ46c8VEWDHh