### PR TITLE
docs: correct the diagram/cell guidance in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,23 +118,52 @@ diagram = api.create_threat_model_diagram(request, tm_id)
 ```
 
 **Updating Diagrams (use DfdDiagramInput, NOT DfdDiagram):**
+
+Build the model with `from_dict()`. Do **not** pass cell dictionaries to the
+constructor — see the warning below.
+
 ```python
 from tmi_client.models.dfd_diagram_input import DfdDiagramInput
 
-# CORRECT - DfdDiagramInput for updates (no readOnly fields)
-update = DfdDiagramInput(
-    type="DFD-1.0.0",
-    name="Updated Name",
-    cells=[...]
-)
+# CORRECT - from_dict() resolves the cells oneOf and validates each cell
+update = DfdDiagramInput.from_dict({
+    "type": "DFD-1.0.0",
+    "name": "Updated Name",
+    "cells": [...],
+})
 updated_diagram = api.update_threat_model_diagram(update, tm_id, diagram_id)
 ```
 
+> **⚠ Do not construct diagrams with `DfdDiagramInput(cells=[...])`.**
+> Passing cell dictionaries to the constructor does not resolve the `cells`
+> `oneOf`: `actual_instance` stays `None` and the request body serialises to
+> `"cells": [null, null]`, silently discarding every cell. It raises no error,
+> and it accepts outright invalid cells. `from_dict()` resolves the union and
+> rejects bad cells. Tracked in issue #41.
+>
+> Scalar-only models are unaffected — the trap is specific to `oneOf` fields
+> such as `cells`.
+
 **Reading Diagrams:**
+
+> **⚠ Currently broken — `get_threat_model_diagram()` raises `RecursionError`.**
+> The generated `DfdDiagram` carries a self-referential discriminator mapping
+> (`'DFD-1.0.0': 'DfdDiagram'`), so `DfdDiagram.from_dict()` dispatches to
+> itself indefinitely. `api_client` deserialises 200 responses via
+> `klass.from_dict(...)`, so every DFD diagram read hits it. Affects both
+> `v1.3.0` and `v1.8.3`. Tracked in issue #41.
+
 ```python
-# Returns DfdDiagram (with readOnly fields: id, created_at, modified_at)
+# Intended behaviour: returns DfdDiagram (with readOnly fields: id,
+# created_at, modified_at). Blocked by the defect above.
 diagram = api.get_threat_model_diagram(tm_id, diagram_id)
 ```
+
+Because reading is broken, the read-modify-write round trip does not currently
+work either. Note that even once it is fixed, `DfdDiagramInput.from_dict(
+diagram.to_dict())` will still fail: `to_dict()` leaves native `UUID` objects
+inside cells and the `oneOf` wrapper calls `json.dumps()` on them. Go through
+JSON instead — `DfdDiagramInput.from_dict(json.loads(diagram.to_json()))`.
 
 ### Input vs Output Schemas
 
@@ -223,12 +252,27 @@ Diagrams use the AntV X6 graph library format for cells (nodes and edges). Cells
 # Edge example
 {
     "id": "uuid",
-    "shape": "edge",
+    "shape": "flow",
     "source": {"cell": "source-node-id"},
     "target": {"cell": "target-node-id"},
     "attrs": {"line": {"stroke": "#333"}}
 }
 ```
+
+Constraints enforced by the generated models — a cell violating any of these is
+rejected when the diagram is built with `from_dict()`:
+
+| Field | Constraint |
+|---|---|
+| `Node.shape` | one of `actor`, `process`, `store`, `security-boundary`, `text-box` |
+| `Edge.shape` | `flow` — **not** `edge` |
+| `Node.width` | `>= 40` |
+| `Node.height` | `>= 30` |
+
+Each entry in `cells` is a `oneOf` over `Node` and `Edge`, and must match exactly
+one. Build diagrams with `from_dict()` so the union is resolved and these
+constraints are actually applied; the constructor silently accepts anything and
+discards it (see the warning under **Updating Diagrams**).
 
 ## Documentation Structure
 


### PR DESCRIPTION
Three pieces of advice in `CLAUDE.md` did not work against the generated client. All were verified by execution against **both** `python-client-generated/v1.3.0` and `v1.8.3`; behaviour is identical in each. Defects tracked in #41.

## 1. `DfdDiagramInput(cells=[...])` silently discards every cell

The documented update pattern passed cell dicts to the constructor. That does not resolve the `cells` `oneOf` — `actual_instance` stays `None` and the **serialised request body** is `"cells": [null, null]`:

```python
ApiClient().sanitize_for_serialization(
    DfdDiagramInput(name="D", type="DFD-1.0.0", cells=[NODE, EDGE])
)["cells"]
# [None, None]
```

No error is raised, and `cells=[{"garbage": 1}]` is accepted too. Replaced with `DfdDiagramInput.from_dict({...})`, which resolves the union and validates each cell.

## 2. The edge example used an invalid shape

`"shape": "edge"` is rejected — the generated `Edge` model constrains `shape` to the enum `('flow')`. Corrected to `"flow"`, and the enforced constraints are now stated explicitly:

| Field | Constraint |
|---|---|
| `Node.shape` | `actor`, `process`, `store`, `security-boundary`, `text-box` |
| `Edge.shape` | `flow` — **not** `edge` |
| `Node.width` | `>= 40` |
| `Node.height` | `>= 30` |

## 3. "Reading Diagrams" is broken outright

`get_threat_model_diagram()` raises `RecursionError`. `DfdDiagram` has a self-referential discriminator mapping (`'DFD-1.0.0': 'DfdDiagram'`), so `DfdDiagram.from_dict()` dispatches to itself indefinitely — and `ApiClient.__deserialize_model` deserialises `200` responses via `klass.from_dict()`, with `get_threat_model_diagram` mapping `200` → `DfdDiagram`.

Rather than leave an example that cannot work, it is now marked as broken with the mechanism explained. The read-modify-write note also records that `to_dict()` output cannot be fed back into `from_dict()` (native `UUID`s vs `json.dumps`), and gives the working idiom `DfdDiagramInput.from_dict(json.loads(diagram.to_json()))`.

## Verification

Every example and every table row was executed, not inferred:

- documented `CreateDiagramRequest` and the new `from_dict` update pattern both construct correctly
- boundary values checked individually — width 39 rejected / 40 accepted, height 29 rejected / 30 accepted
- all five node shapes accepted; a bogus shape rejected; `"shape": "edge"` rejected
- the `to_json()` round-trip workaround confirmed working where `to_dict()` fails

Docs-only change — no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116ox2SywZRuZ46c8VEWDHh