### PR TITLE
fix: repair three oneOf/discriminator defects in the Python client

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,7 @@ tox -- -k test_dfd_diagram
 
 ## Critical OpenAPI Issues (RESOLVED)
 
-The Python client was previously patched to fix 6 critical OpenAPI specification issues. With the migration from swagger-codegen to openapi-generator, most of these patches are no longer needed. The only remaining patch is the UUID/datetime regex validator fix. See `MIGRATION_GUIDE.md` for full details.
+The Python client was previously patched to fix 6 critical OpenAPI specification issues. With the migration from swagger-codegen to openapi-generator, those spec-level patches are no longer needed; see `MIGRATION_GUIDE.md` for full details. What remains are patches for openapi-generator's own codegen bugs, all applied by `regenerate_python.py` and listed in each version's `REGENERATION_REPORT.md`: the UUID/datetime regex validator fix and the three `oneOf`/discriminator fixes described under **Reading Diagrams** below.
 
 ### Key API Patterns
 
@@ -119,13 +119,12 @@ diagram = api.create_threat_model_diagram(request, tm_id)
 
 **Updating Diagrams (use DfdDiagramInput, NOT DfdDiagram):**
 
-Build the model with `from_dict()`. Do **not** pass cell dictionaries to the
-constructor — see the warning below.
+Either `from_dict()` or the constructor works — both resolve the `cells`
+`oneOf` and reject cells that match neither `Node` nor `Edge`.
 
 ```python
 from tmi_client.models.dfd_diagram_input import DfdDiagramInput
 
-# CORRECT - from_dict() resolves the cells oneOf and validates each cell
 update = DfdDiagramInput.from_dict({
     "type": "DFD-1.0.0",
     "name": "Updated Name",
@@ -134,36 +133,29 @@ update = DfdDiagramInput.from_dict({
 updated_diagram = api.update_threat_model_diagram(update, tm_id, diagram_id)
 ```
 
-> **⚠ Do not construct diagrams with `DfdDiagramInput(cells=[...])`.**
-> Passing cell dictionaries to the constructor does not resolve the `cells`
-> `oneOf`: `actual_instance` stays `None` and the request body serialises to
-> `"cells": [null, null]`, silently discarding every cell. It raises no error,
-> and it accepts outright invalid cells. `from_dict()` resolves the union and
-> rejects bad cells. Tracked in issue #41.
->
-> Scalar-only models are unaffected — the trap is specific to `oneOf` fields
-> such as `cells`.
-
 **Reading Diagrams:**
 
-> **⚠ Currently broken — `get_threat_model_diagram()` raises `RecursionError`.**
-> The generated `DfdDiagram` carries a self-referential discriminator mapping
-> (`'DFD-1.0.0': 'DfdDiagram'`), so `DfdDiagram.from_dict()` dispatches to
-> itself indefinitely. `api_client` deserialises 200 responses via
-> `klass.from_dict(...)`, so every DFD diagram read hits it. Affects both
-> `v1.3.0` and `v1.8.3`. Tracked in issue #41.
-
 ```python
-# Intended behaviour: returns DfdDiagram (with readOnly fields: id,
-# created_at, modified_at). Blocked by the defect above.
+# Returns DfdDiagram, including the readOnly fields id, created_at, modified_at.
 diagram = api.get_threat_model_diagram(tm_id, diagram_id)
 ```
 
-Because reading is broken, the read-modify-write round trip does not currently
-work either. Note that even once it is fixed, `DfdDiagramInput.from_dict(
-diagram.to_dict())` will still fail: `to_dict()` leaves native `UUID` objects
-inside cells and the `oneOf` wrapper calls `json.dumps()` on them. Go through
-JSON instead — `DfdDiagramInput.from_dict(json.loads(diagram.to_json()))`.
+Read-modify-write round trips work in either direction:
+
+```python
+diagram = api.get_threat_model_diagram(tm_id, diagram_id)
+update = DfdDiagramInput.from_dict(diagram.to_dict())
+update.name = "Renamed"
+api.update_threat_model_diagram(update, tm_id, diagram_id)
+```
+
+> The three `oneOf`/discriminator defects tracked in issue #41 — cells silently
+> discarded by the constructor, `to_dict()` output not round-tripping through
+> `from_dict()`, and `DfdDiagram.from_dict()` recursing forever — are fixed by
+> `patch_oneof_constructor_coercion`, `patch_oneof_json_safety` and
+> `patch_self_referential_discriminator` in `regenerate_python.py`. They are
+> generator bugs, so the patches must survive every regeneration;
+> `test_diagram_fixes.py` asserts all three.
 
 ### Input vs Output Schemas
 
@@ -260,7 +252,7 @@ Diagrams use the AntV X6 graph library format for cells (nodes and edges). Cells
 ```
 
 Constraints enforced by the generated models — a cell violating any of these is
-rejected when the diagram is built with `from_dict()`:
+rejected however the diagram is built:
 
 | Field | Constraint |
 |---|---|
@@ -270,9 +262,7 @@ rejected when the diagram is built with `from_dict()`:
 | `Node.height` | `>= 30` |
 
 Each entry in `cells` is a `oneOf` over `Node` and `Edge`, and must match exactly
-one. Build diagrams with `from_dict()` so the union is resolved and these
-constraints are actually applied; the constructor silently accepts anything and
-discards it (see the warning under **Updating Diagrams**).
+one.
 
 ## Documentation Structure
 

--- a/python-client-generated/v1.3.0/test_diagram_fixes.py
+++ b/python-client-generated/v1.3.0/test_diagram_fixes.py
@@ -23,16 +23,19 @@ Covered:
      so an unguarded `re.match()` raises TypeError on a UUID or datetime.
   4. Validation still rejects genuinely invalid input, so 1 and 3 cannot pass
      by having been neutered.
-
-Cells are built with `from_dict`, not the constructor. Passing raw dicts to the
-constructor does *not* resolve the `oneOf` and silently yields empty cells —
-see the KNOWN DEFECTS note at the bottom of this file.
+  5. The three `oneOf`/discriminator defects fixed by
+     `patch_oneof_constructor_coercion`, `patch_oneof_json_safety` and
+     `patch_self_referential_discriminator` in regenerate_python.py: raw dicts
+     passed to a model constructor must resolve the `oneOf`; `to_dict()` output
+     must round-trip back through `from_dict()`; and reading a DFD diagram must
+     not recurse forever.
 
 Version-portable: asserts on the presence or absence of specific fields rather
 than exact field lists, since the schema grows between API versions.
 """
 from __future__ import annotations
 
+import json
 import sys
 import traceback
 from datetime import datetime, timezone
@@ -196,6 +199,88 @@ def _undersized_node_rejected() -> None:
     raise AssertionError("an undersized node was accepted")
 
 
+@check("raw dict cells passed to the constructor resolve the oneOf")
+def _constructor_resolves_cells() -> None:
+    # Regression: the oneOf wrapper only resolved raw dicts via from_dict(), so
+    # pydantic validation of a constructor argument left actual_instance None
+    # and to_dict() emitted "cells": [None, None] — silently dropping cells.
+    diagram = DfdDiagramInput(
+        name="Test Diagram", type="DFD-1.0.0", cells=[NODE_CELL, EDGE_CELL]
+    )
+    kinds = [type(c.actual_instance).__name__ for c in diagram.cells]
+    assert kinds == ["Node", "Edge"], f"oneOf resolved to {kinds}"
+    cells = diagram.to_dict()["cells"]
+    assert all(c is not None for c in cells), f"cells lost on to_dict: {cells}"
+
+
+@check("the constructor still rejects a cell matching neither oneOf branch")
+def _constructor_rejects_invalid_cell() -> None:
+    # Guards the fix above from being a blanket "accept anything" coercion.
+    try:
+        DfdDiagramInput(
+            name="Test Diagram", type="DFD-1.0.0", cells=[{"not_a_cell": True}]
+        )
+    except Exception:
+        return
+    raise AssertionError("a malformed cell was accepted by the constructor")
+
+
+@check("to_dict output round-trips back through from_dict")
+def _to_dict_round_trips() -> None:
+    # Regression: to_dict() leaves native UUID objects inside cells and the
+    # oneOf wrapper's from_dict did json.dumps(obj), raising
+    # "TypeError: Object of type UUID is not JSON serializable".
+    original = _input_with_cells([NODE_CELL, EDGE_CELL])
+    restored = DfdDiagramInput.from_dict(original.to_dict())
+    assert restored is not None, "round-tripped from_dict returned None"
+    kinds = [type(c.actual_instance).__name__ for c in restored.cells]
+    assert kinds == ["Node", "Edge"], f"oneOf resolved to {kinds}"
+    assert restored.to_dict() == original.to_dict(), "round trip changed the model"
+
+
+@check("DfdDiagram.from_dict builds a diagram instead of recursing")
+def _output_from_dict_terminates() -> None:
+    # Regression: DfdDiagram's discriminator maps 'DFD-1.0.0' to 'DfdDiagram',
+    # so from_dict dispatched to itself forever. ApiClient deserialises 200
+    # responses via klass.from_dict(), so every DFD diagram read raised
+    # RecursionError.
+    diagram = DfdDiagram.from_dict(
+        {
+            "id": DIAGRAM_ID,
+            "name": "Test Diagram",
+            "type": "DFD-1.0.0",
+            "created_at": "2026-01-01T00:00:00Z",
+            "modified_at": "2026-01-01T00:00:00Z",
+            "cells": [NODE_CELL, EDGE_CELL],
+        }
+    )
+    assert isinstance(diagram, DfdDiagram), f"got {type(diagram).__name__}"
+    assert diagram.id == UUID(DIAGRAM_ID), f"id not preserved: {diagram.id}"
+    kinds = [type(c.actual_instance).__name__ for c in diagram.cells]
+    assert kinds == ["Node", "Edge"], f"oneOf resolved to {kinds}"
+
+
+@check("a diagram read round-trips into the input model")
+def _read_modify_write_round_trip() -> None:
+    # The read-modify-write flow documented in CLAUDE.md: read a diagram, feed
+    # it back into the input model, write it out again.
+    diagram = DfdDiagram.from_dict(
+        {
+            "id": DIAGRAM_ID,
+            "name": "Test Diagram",
+            "type": "DFD-1.0.0",
+            "created_at": "2026-01-01T00:00:00Z",
+            "modified_at": "2026-01-01T00:00:00Z",
+            "cells": [NODE_CELL, EDGE_CELL],
+        }
+    )
+    update = DfdDiagramInput.from_dict(json.loads(diagram.to_json()))
+    assert update is not None, "from_dict returned None"
+    assert len(update.cells) == 2, f"expected 2 cells, got {len(update.cells)}"
+    for field in READONLY_FIELDS:
+        assert field not in update.to_dict(), f"readOnly field {field} leaked into input"
+
+
 def main() -> int:
     width = max(len(name) for name, _, _ in _results)
     for name, status, detail in _results:
@@ -210,17 +295,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     sys.exit(main())
-
-
-# KNOWN DEFECTS in the generated client (not asserted here, so this file stays
-# green; see the repo issue tracker):
-#
-# 1. Passing raw dicts as `cells` to the model constructor — the pattern shown
-#    in CLAUDE.md — does not resolve the oneOf. `actual_instance` stays None and
-#    `to_dict()` emits `"cells": [None, ...]`, silently discarding every cell.
-#    Use `DfdDiagramInput.from_dict({...})`, as this file does.
-#
-# 2. `to_dict()` output cannot be fed back into `from_dict()`. to_dict() leaves
-#    native UUID objects inside cells, and the oneOf wrapper's from_dict does
-#    `json.dumps(obj)`, which raises
-#    "TypeError: Object of type UUID is not JSON serializable".

--- a/python-client-generated/v1.3.0/tmi_client/models/dfd_diagram.py
+++ b/python-client-generated/v1.3.0/tmi_client/models/dfd_diagram.py
@@ -167,7 +167,10 @@ class DfdDiagram(BaseDiagram):
         # look up the object type based on discriminator mapping
         object_type = cls.get_discriminator_value(obj)
         if object_type ==  'DfdDiagram':
-            return import_module("tmi_client.models.dfd_diagram").DfdDiagram.from_dict(obj)
+            # Patched by regenerate_python.py: the discriminator maps this
+            # value back to this same class, so dispatching would recurse
+            # forever.  Validate directly instead.
+            return cls.model_validate(obj)
         if object_type ==  'Diagram':
             return import_module("tmi_client.models.diagram").Diagram.from_dict(obj)
 

--- a/python-client-generated/v1.3.0/tmi_client/models/dfd_diagram_all_of_cells.py
+++ b/python-client-generated/v1.3.0/tmi_client/models/dfd_diagram_all_of_cells.py
@@ -16,7 +16,8 @@
 from __future__ import annotations
 import json
 import pprint
-from pydantic import BaseModel, ConfigDict, Field, StrictStr, ValidationError, field_validator
+from pydantic import BaseModel, ConfigDict, Field, StrictStr, ValidationError, field_validator, model_validator
+from pydantic_core import to_jsonable_python
 from typing import Any, List, Optional
 from tmi_client.models.edge import Edge
 from tmi_client.models.node import Node
@@ -56,6 +57,20 @@ class DfdDiagramAllOfCells(BaseModel):
         else:
             super().__init__(**kwargs)
 
+    # Patched by regenerate_python.py: openapi-generator resolves the oneOf
+    # only inside from_dict()/from_json().  A raw dict arriving through
+    # ordinary Pydantic validation -- a constructor argument, or a parent
+    # model's model_validate() -- matched none of this wrapper's fields, so
+    # `actual_instance` stayed None and the value serialised away as null.
+    # Route those payloads through from_dict() so the union is resolved and
+    # a non-matching payload is rejected rather than silently discarded.
+    @model_validator(mode='before')
+    @classmethod
+    def _resolve_oneof_payload(cls, data: Any) -> Any:
+        if isinstance(data, dict) and data and not set(data) & set(cls.model_fields):
+            return {"actual_instance": cls.from_dict(data).actual_instance}
+        return data
+
     @field_validator('actual_instance')
     def actual_instance_must_validate_oneof(cls, v):
         instance = DfdDiagramAllOfCells.model_construct()
@@ -82,7 +97,7 @@ class DfdDiagramAllOfCells(BaseModel):
 
     @classmethod
     def from_dict(cls, obj: Union[str, Dict[str, Any]]) -> Self:
-        return cls.from_json(json.dumps(obj))
+        return cls.from_json(json.dumps(to_jsonable_python(obj)))
 
     @classmethod
     def from_json(cls, json_str: str) -> Self:

--- a/python-client-generated/v1.3.0/tmi_client/models/dfd_diagram_input_all_of_cells.py
+++ b/python-client-generated/v1.3.0/tmi_client/models/dfd_diagram_input_all_of_cells.py
@@ -16,7 +16,8 @@
 from __future__ import annotations
 import json
 import pprint
-from pydantic import BaseModel, ConfigDict, Field, StrictStr, ValidationError, field_validator
+from pydantic import BaseModel, ConfigDict, Field, StrictStr, ValidationError, field_validator, model_validator
+from pydantic_core import to_jsonable_python
 from typing import Any, List, Optional
 from tmi_client.models.edge import Edge
 from tmi_client.models.node import Node
@@ -56,6 +57,20 @@ class DfdDiagramInputAllOfCells(BaseModel):
         else:
             super().__init__(**kwargs)
 
+    # Patched by regenerate_python.py: openapi-generator resolves the oneOf
+    # only inside from_dict()/from_json().  A raw dict arriving through
+    # ordinary Pydantic validation -- a constructor argument, or a parent
+    # model's model_validate() -- matched none of this wrapper's fields, so
+    # `actual_instance` stayed None and the value serialised away as null.
+    # Route those payloads through from_dict() so the union is resolved and
+    # a non-matching payload is rejected rather than silently discarded.
+    @model_validator(mode='before')
+    @classmethod
+    def _resolve_oneof_payload(cls, data: Any) -> Any:
+        if isinstance(data, dict) and data and not set(data) & set(cls.model_fields):
+            return {"actual_instance": cls.from_dict(data).actual_instance}
+        return data
+
     @field_validator('actual_instance')
     def actual_instance_must_validate_oneof(cls, v):
         instance = DfdDiagramInputAllOfCells.model_construct()
@@ -82,7 +97,7 @@ class DfdDiagramInputAllOfCells(BaseModel):
 
     @classmethod
     def from_dict(cls, obj: Union[str, Dict[str, Any]]) -> Self:
-        return cls.from_json(json.dumps(obj))
+        return cls.from_json(json.dumps(to_jsonable_python(obj)))
 
     @classmethod
     def from_json(cls, json_str: str) -> Self:

--- a/python-client-generated/v1.3.0/tmi_client/models/edge_connector.py
+++ b/python-client-generated/v1.3.0/tmi_client/models/edge_connector.py
@@ -16,7 +16,8 @@
 from __future__ import annotations
 import json
 import pprint
-from pydantic import BaseModel, ConfigDict, Field, StrictStr, ValidationError, field_validator
+from pydantic import BaseModel, ConfigDict, Field, StrictStr, ValidationError, field_validator, model_validator
+from pydantic_core import to_jsonable_python
 from typing import Any, List, Optional
 from typing_extensions import Annotated
 from tmi_client.models.edge_connector_one_of import EdgeConnectorOneOf
@@ -53,6 +54,20 @@ class EdgeConnector(BaseModel):
         else:
             super().__init__(**kwargs)
 
+    # Patched by regenerate_python.py: openapi-generator resolves the oneOf
+    # only inside from_dict()/from_json().  A raw dict arriving through
+    # ordinary Pydantic validation -- a constructor argument, or a parent
+    # model's model_validate() -- matched none of this wrapper's fields, so
+    # `actual_instance` stayed None and the value serialised away as null.
+    # Route those payloads through from_dict() so the union is resolved and
+    # a non-matching payload is rejected rather than silently discarded.
+    @model_validator(mode='before')
+    @classmethod
+    def _resolve_oneof_payload(cls, data: Any) -> Any:
+        if isinstance(data, dict) and data and not set(data) & set(cls.model_fields):
+            return {"actual_instance": cls.from_dict(data).actual_instance}
+        return data
+
     @field_validator('actual_instance')
     def actual_instance_must_validate_oneof(cls, v):
         instance = EdgeConnector.model_construct()
@@ -80,7 +95,7 @@ class EdgeConnector(BaseModel):
 
     @classmethod
     def from_dict(cls, obj: Union[str, Dict[str, Any]]) -> Self:
-        return cls.from_json(json.dumps(obj))
+        return cls.from_json(json.dumps(to_jsonable_python(obj)))
 
     @classmethod
     def from_json(cls, json_str: str) -> Self:

--- a/python-client-generated/v1.3.0/tmi_client/models/edge_label_position.py
+++ b/python-client-generated/v1.3.0/tmi_client/models/edge_label_position.py
@@ -16,7 +16,8 @@
 from __future__ import annotations
 import json
 import pprint
-from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt, StrictStr, ValidationError, field_validator
+from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt, StrictStr, ValidationError, field_validator, model_validator
+from pydantic_core import to_jsonable_python
 from typing import Any, List, Optional, Union
 from tmi_client.models.edge_label_position_one_of import EdgeLabelPositionOneOf
 from pydantic import StrictStr, Field
@@ -52,6 +53,20 @@ class EdgeLabelPosition(BaseModel):
         else:
             super().__init__(**kwargs)
 
+    # Patched by regenerate_python.py: openapi-generator resolves the oneOf
+    # only inside from_dict()/from_json().  A raw dict arriving through
+    # ordinary Pydantic validation -- a constructor argument, or a parent
+    # model's model_validate() -- matched none of this wrapper's fields, so
+    # `actual_instance` stayed None and the value serialised away as null.
+    # Route those payloads through from_dict() so the union is resolved and
+    # a non-matching payload is rejected rather than silently discarded.
+    @model_validator(mode='before')
+    @classmethod
+    def _resolve_oneof_payload(cls, data: Any) -> Any:
+        if isinstance(data, dict) and data and not set(data) & set(cls.model_fields):
+            return {"actual_instance": cls.from_dict(data).actual_instance}
+        return data
+
     @field_validator('actual_instance')
     def actual_instance_must_validate_oneof(cls, v):
         instance = EdgeLabelPosition.model_construct()
@@ -79,7 +94,7 @@ class EdgeLabelPosition(BaseModel):
 
     @classmethod
     def from_dict(cls, obj: Union[str, Dict[str, Any]]) -> Self:
-        return cls.from_json(json.dumps(obj))
+        return cls.from_json(json.dumps(to_jsonable_python(obj)))
 
     @classmethod
     def from_json(cls, json_str: str) -> Self:

--- a/python-client-generated/v1.3.0/tmi_client/models/edge_label_position_one_of_offset.py
+++ b/python-client-generated/v1.3.0/tmi_client/models/edge_label_position_one_of_offset.py
@@ -16,7 +16,8 @@
 from __future__ import annotations
 import json
 import pprint
-from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt, StrictStr, ValidationError, field_validator
+from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt, StrictStr, ValidationError, field_validator, model_validator
+from pydantic_core import to_jsonable_python
 from typing import Any, List, Optional, Union
 from tmi_client.models.edge_label_position_one_of_offset_one_of import EdgeLabelPositionOneOfOffsetOneOf
 from pydantic import StrictStr, Field
@@ -52,6 +53,20 @@ class EdgeLabelPositionOneOfOffset(BaseModel):
         else:
             super().__init__(**kwargs)
 
+    # Patched by regenerate_python.py: openapi-generator resolves the oneOf
+    # only inside from_dict()/from_json().  A raw dict arriving through
+    # ordinary Pydantic validation -- a constructor argument, or a parent
+    # model's model_validate() -- matched none of this wrapper's fields, so
+    # `actual_instance` stayed None and the value serialised away as null.
+    # Route those payloads through from_dict() so the union is resolved and
+    # a non-matching payload is rejected rather than silently discarded.
+    @model_validator(mode='before')
+    @classmethod
+    def _resolve_oneof_payload(cls, data: Any) -> Any:
+        if isinstance(data, dict) and data and not set(data) & set(cls.model_fields):
+            return {"actual_instance": cls.from_dict(data).actual_instance}
+        return data
+
     @field_validator('actual_instance')
     def actual_instance_must_validate_oneof(cls, v):
         instance = EdgeLabelPositionOneOfOffset.model_construct()
@@ -79,7 +94,7 @@ class EdgeLabelPositionOneOfOffset(BaseModel):
 
     @classmethod
     def from_dict(cls, obj: Union[str, Dict[str, Any]]) -> Self:
-        return cls.from_json(json.dumps(obj))
+        return cls.from_json(json.dumps(to_jsonable_python(obj)))
 
     @classmethod
     def from_json(cls, json_str: str) -> Self:

--- a/python-client-generated/v1.3.0/tmi_client/models/edge_router.py
+++ b/python-client-generated/v1.3.0/tmi_client/models/edge_router.py
@@ -16,7 +16,8 @@
 from __future__ import annotations
 import json
 import pprint
-from pydantic import BaseModel, ConfigDict, Field, StrictStr, ValidationError, field_validator
+from pydantic import BaseModel, ConfigDict, Field, StrictStr, ValidationError, field_validator, model_validator
+from pydantic_core import to_jsonable_python
 from typing import Any, List, Optional
 from typing_extensions import Annotated
 from tmi_client.models.edge_router_one_of import EdgeRouterOneOf
@@ -53,6 +54,20 @@ class EdgeRouter(BaseModel):
         else:
             super().__init__(**kwargs)
 
+    # Patched by regenerate_python.py: openapi-generator resolves the oneOf
+    # only inside from_dict()/from_json().  A raw dict arriving through
+    # ordinary Pydantic validation -- a constructor argument, or a parent
+    # model's model_validate() -- matched none of this wrapper's fields, so
+    # `actual_instance` stayed None and the value serialised away as null.
+    # Route those payloads through from_dict() so the union is resolved and
+    # a non-matching payload is rejected rather than silently discarded.
+    @model_validator(mode='before')
+    @classmethod
+    def _resolve_oneof_payload(cls, data: Any) -> Any:
+        if isinstance(data, dict) and data and not set(data) & set(cls.model_fields):
+            return {"actual_instance": cls.from_dict(data).actual_instance}
+        return data
+
     @field_validator('actual_instance')
     def actual_instance_must_validate_oneof(cls, v):
         instance = EdgeRouter.model_construct()
@@ -80,7 +95,7 @@ class EdgeRouter(BaseModel):
 
     @classmethod
     def from_dict(cls, obj: Union[str, Dict[str, Any]]) -> Self:
-        return cls.from_json(json.dumps(obj))
+        return cls.from_json(json.dumps(to_jsonable_python(obj)))
 
     @classmethod
     def from_json(cls, json_str: str) -> Self:

--- a/python-client-generated/v1.3.0/tmi_client/models/minimal_cell.py
+++ b/python-client-generated/v1.3.0/tmi_client/models/minimal_cell.py
@@ -16,7 +16,8 @@
 from __future__ import annotations
 import json
 import pprint
-from pydantic import BaseModel, ConfigDict, Field, StrictStr, ValidationError, field_validator
+from pydantic import BaseModel, ConfigDict, Field, StrictStr, ValidationError, field_validator, model_validator
+from pydantic_core import to_jsonable_python
 from typing import Any, List, Optional
 from tmi_client.models.minimal_edge import MinimalEdge
 from tmi_client.models.minimal_node import MinimalNode
@@ -56,6 +57,20 @@ class MinimalCell(BaseModel):
         else:
             super().__init__(**kwargs)
 
+    # Patched by regenerate_python.py: openapi-generator resolves the oneOf
+    # only inside from_dict()/from_json().  A raw dict arriving through
+    # ordinary Pydantic validation -- a constructor argument, or a parent
+    # model's model_validate() -- matched none of this wrapper's fields, so
+    # `actual_instance` stayed None and the value serialised away as null.
+    # Route those payloads through from_dict() so the union is resolved and
+    # a non-matching payload is rejected rather than silently discarded.
+    @model_validator(mode='before')
+    @classmethod
+    def _resolve_oneof_payload(cls, data: Any) -> Any:
+        if isinstance(data, dict) and data and not set(data) & set(cls.model_fields):
+            return {"actual_instance": cls.from_dict(data).actual_instance}
+        return data
+
     @field_validator('actual_instance')
     def actual_instance_must_validate_oneof(cls, v):
         instance = MinimalCell.model_construct()
@@ -82,7 +97,7 @@ class MinimalCell(BaseModel):
 
     @classmethod
     def from_dict(cls, obj: Union[str, Dict[str, Any]]) -> Self:
-        return cls.from_json(json.dumps(obj))
+        return cls.from_json(json.dumps(to_jsonable_python(obj)))
 
     @classmethod
     def from_json(cls, json_str: str) -> Self:

--- a/python-client-generated/v1.8.3/test_diagram_fixes.py
+++ b/python-client-generated/v1.8.3/test_diagram_fixes.py
@@ -23,16 +23,19 @@ Covered:
      so an unguarded `re.match()` raises TypeError on a UUID or datetime.
   4. Validation still rejects genuinely invalid input, so 1 and 3 cannot pass
      by having been neutered.
-
-Cells are built with `from_dict`, not the constructor. Passing raw dicts to the
-constructor does *not* resolve the `oneOf` and silently yields empty cells —
-see the KNOWN DEFECTS note at the bottom of this file.
+  5. The three `oneOf`/discriminator defects fixed by
+     `patch_oneof_constructor_coercion`, `patch_oneof_json_safety` and
+     `patch_self_referential_discriminator` in regenerate_python.py: raw dicts
+     passed to a model constructor must resolve the `oneOf`; `to_dict()` output
+     must round-trip back through `from_dict()`; and reading a DFD diagram must
+     not recurse forever.
 
 Version-portable: asserts on the presence or absence of specific fields rather
 than exact field lists, since the schema grows between API versions.
 """
 from __future__ import annotations
 
+import json
 import sys
 import traceback
 from datetime import datetime, timezone
@@ -196,6 +199,88 @@ def _undersized_node_rejected() -> None:
     raise AssertionError("an undersized node was accepted")
 
 
+@check("raw dict cells passed to the constructor resolve the oneOf")
+def _constructor_resolves_cells() -> None:
+    # Regression: the oneOf wrapper only resolved raw dicts via from_dict(), so
+    # pydantic validation of a constructor argument left actual_instance None
+    # and to_dict() emitted "cells": [None, None] — silently dropping cells.
+    diagram = DfdDiagramInput(
+        name="Test Diagram", type="DFD-1.0.0", cells=[NODE_CELL, EDGE_CELL]
+    )
+    kinds = [type(c.actual_instance).__name__ for c in diagram.cells]
+    assert kinds == ["Node", "Edge"], f"oneOf resolved to {kinds}"
+    cells = diagram.to_dict()["cells"]
+    assert all(c is not None for c in cells), f"cells lost on to_dict: {cells}"
+
+
+@check("the constructor still rejects a cell matching neither oneOf branch")
+def _constructor_rejects_invalid_cell() -> None:
+    # Guards the fix above from being a blanket "accept anything" coercion.
+    try:
+        DfdDiagramInput(
+            name="Test Diagram", type="DFD-1.0.0", cells=[{"not_a_cell": True}]
+        )
+    except Exception:
+        return
+    raise AssertionError("a malformed cell was accepted by the constructor")
+
+
+@check("to_dict output round-trips back through from_dict")
+def _to_dict_round_trips() -> None:
+    # Regression: to_dict() leaves native UUID objects inside cells and the
+    # oneOf wrapper's from_dict did json.dumps(obj), raising
+    # "TypeError: Object of type UUID is not JSON serializable".
+    original = _input_with_cells([NODE_CELL, EDGE_CELL])
+    restored = DfdDiagramInput.from_dict(original.to_dict())
+    assert restored is not None, "round-tripped from_dict returned None"
+    kinds = [type(c.actual_instance).__name__ for c in restored.cells]
+    assert kinds == ["Node", "Edge"], f"oneOf resolved to {kinds}"
+    assert restored.to_dict() == original.to_dict(), "round trip changed the model"
+
+
+@check("DfdDiagram.from_dict builds a diagram instead of recursing")
+def _output_from_dict_terminates() -> None:
+    # Regression: DfdDiagram's discriminator maps 'DFD-1.0.0' to 'DfdDiagram',
+    # so from_dict dispatched to itself forever. ApiClient deserialises 200
+    # responses via klass.from_dict(), so every DFD diagram read raised
+    # RecursionError.
+    diagram = DfdDiagram.from_dict(
+        {
+            "id": DIAGRAM_ID,
+            "name": "Test Diagram",
+            "type": "DFD-1.0.0",
+            "created_at": "2026-01-01T00:00:00Z",
+            "modified_at": "2026-01-01T00:00:00Z",
+            "cells": [NODE_CELL, EDGE_CELL],
+        }
+    )
+    assert isinstance(diagram, DfdDiagram), f"got {type(diagram).__name__}"
+    assert diagram.id == UUID(DIAGRAM_ID), f"id not preserved: {diagram.id}"
+    kinds = [type(c.actual_instance).__name__ for c in diagram.cells]
+    assert kinds == ["Node", "Edge"], f"oneOf resolved to {kinds}"
+
+
+@check("a diagram read round-trips into the input model")
+def _read_modify_write_round_trip() -> None:
+    # The read-modify-write flow documented in CLAUDE.md: read a diagram, feed
+    # it back into the input model, write it out again.
+    diagram = DfdDiagram.from_dict(
+        {
+            "id": DIAGRAM_ID,
+            "name": "Test Diagram",
+            "type": "DFD-1.0.0",
+            "created_at": "2026-01-01T00:00:00Z",
+            "modified_at": "2026-01-01T00:00:00Z",
+            "cells": [NODE_CELL, EDGE_CELL],
+        }
+    )
+    update = DfdDiagramInput.from_dict(json.loads(diagram.to_json()))
+    assert update is not None, "from_dict returned None"
+    assert len(update.cells) == 2, f"expected 2 cells, got {len(update.cells)}"
+    for field in READONLY_FIELDS:
+        assert field not in update.to_dict(), f"readOnly field {field} leaked into input"
+
+
 def main() -> int:
     width = max(len(name) for name, _, _ in _results)
     for name, status, detail in _results:
@@ -210,17 +295,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     sys.exit(main())
-
-
-# KNOWN DEFECTS in the generated client (not asserted here, so this file stays
-# green; see the repo issue tracker):
-#
-# 1. Passing raw dicts as `cells` to the model constructor — the pattern shown
-#    in CLAUDE.md — does not resolve the oneOf. `actual_instance` stays None and
-#    `to_dict()` emits `"cells": [None, ...]`, silently discarding every cell.
-#    Use `DfdDiagramInput.from_dict({...})`, as this file does.
-#
-# 2. `to_dict()` output cannot be fed back into `from_dict()`. to_dict() leaves
-#    native UUID objects inside cells, and the oneOf wrapper's from_dict does
-#    `json.dumps(obj)`, which raises
-#    "TypeError: Object of type UUID is not JSON serializable".

--- a/python-client-generated/v1.8.3/tmi_client/models/dfd_diagram.py
+++ b/python-client-generated/v1.8.3/tmi_client/models/dfd_diagram.py
@@ -170,7 +170,10 @@ class DfdDiagram(BaseDiagram):
         # look up the object type based on discriminator mapping
         object_type = cls.get_discriminator_value(obj)
         if object_type ==  'DfdDiagram':
-            return import_module("tmi_client.models.dfd_diagram").DfdDiagram.from_dict(obj)
+            # Patched by regenerate_python.py: the discriminator maps this
+            # value back to this same class, so dispatching would recurse
+            # forever.  Validate directly instead.
+            return cls.model_validate(obj)
         if object_type ==  'Diagram':
             return import_module("tmi_client.models.diagram").Diagram.from_dict(obj)
 

--- a/python-client-generated/v1.8.3/tmi_client/models/dfd_diagram_all_of_cells.py
+++ b/python-client-generated/v1.8.3/tmi_client/models/dfd_diagram_all_of_cells.py
@@ -16,7 +16,8 @@
 from __future__ import annotations
 import json
 import pprint
-from pydantic import BaseModel, ConfigDict, Field, StrictStr, ValidationError, field_validator
+from pydantic import BaseModel, ConfigDict, Field, StrictStr, ValidationError, field_validator, model_validator
+from pydantic_core import to_jsonable_python
 from typing import Any, List, Optional
 from tmi_client.models.edge import Edge
 from tmi_client.models.node import Node
@@ -56,6 +57,20 @@ class DfdDiagramAllOfCells(BaseModel):
         else:
             super().__init__(**kwargs)
 
+    # Patched by regenerate_python.py: openapi-generator resolves the oneOf
+    # only inside from_dict()/from_json().  A raw dict arriving through
+    # ordinary Pydantic validation -- a constructor argument, or a parent
+    # model's model_validate() -- matched none of this wrapper's fields, so
+    # `actual_instance` stayed None and the value serialised away as null.
+    # Route those payloads through from_dict() so the union is resolved and
+    # a non-matching payload is rejected rather than silently discarded.
+    @model_validator(mode='before')
+    @classmethod
+    def _resolve_oneof_payload(cls, data: Any) -> Any:
+        if isinstance(data, dict) and data and not set(data) & set(cls.model_fields):
+            return {"actual_instance": cls.from_dict(data).actual_instance}
+        return data
+
     @field_validator('actual_instance')
     def actual_instance_must_validate_oneof(cls, v):
         instance = DfdDiagramAllOfCells.model_construct()
@@ -82,7 +97,7 @@ class DfdDiagramAllOfCells(BaseModel):
 
     @classmethod
     def from_dict(cls, obj: Union[str, Dict[str, Any]]) -> Self:
-        return cls.from_json(json.dumps(obj))
+        return cls.from_json(json.dumps(to_jsonable_python(obj)))
 
     @classmethod
     def from_json(cls, json_str: str) -> Self:

--- a/python-client-generated/v1.8.3/tmi_client/models/dfd_diagram_input_all_of_cells.py
+++ b/python-client-generated/v1.8.3/tmi_client/models/dfd_diagram_input_all_of_cells.py
@@ -16,7 +16,8 @@
 from __future__ import annotations
 import json
 import pprint
-from pydantic import BaseModel, ConfigDict, Field, StrictStr, ValidationError, field_validator
+from pydantic import BaseModel, ConfigDict, Field, StrictStr, ValidationError, field_validator, model_validator
+from pydantic_core import to_jsonable_python
 from typing import Any, List, Optional
 from tmi_client.models.edge import Edge
 from tmi_client.models.node import Node
@@ -56,6 +57,20 @@ class DfdDiagramInputAllOfCells(BaseModel):
         else:
             super().__init__(**kwargs)
 
+    # Patched by regenerate_python.py: openapi-generator resolves the oneOf
+    # only inside from_dict()/from_json().  A raw dict arriving through
+    # ordinary Pydantic validation -- a constructor argument, or a parent
+    # model's model_validate() -- matched none of this wrapper's fields, so
+    # `actual_instance` stayed None and the value serialised away as null.
+    # Route those payloads through from_dict() so the union is resolved and
+    # a non-matching payload is rejected rather than silently discarded.
+    @model_validator(mode='before')
+    @classmethod
+    def _resolve_oneof_payload(cls, data: Any) -> Any:
+        if isinstance(data, dict) and data and not set(data) & set(cls.model_fields):
+            return {"actual_instance": cls.from_dict(data).actual_instance}
+        return data
+
     @field_validator('actual_instance')
     def actual_instance_must_validate_oneof(cls, v):
         instance = DfdDiagramInputAllOfCells.model_construct()
@@ -82,7 +97,7 @@ class DfdDiagramInputAllOfCells(BaseModel):
 
     @classmethod
     def from_dict(cls, obj: Union[str, Dict[str, Any]]) -> Self:
-        return cls.from_json(json.dumps(obj))
+        return cls.from_json(json.dumps(to_jsonable_python(obj)))
 
     @classmethod
     def from_json(cls, json_str: str) -> Self:

--- a/python-client-generated/v1.8.3/tmi_client/models/edge_connector.py
+++ b/python-client-generated/v1.8.3/tmi_client/models/edge_connector.py
@@ -16,7 +16,8 @@
 from __future__ import annotations
 import json
 import pprint
-from pydantic import BaseModel, ConfigDict, Field, StrictStr, ValidationError, field_validator
+from pydantic import BaseModel, ConfigDict, Field, StrictStr, ValidationError, field_validator, model_validator
+from pydantic_core import to_jsonable_python
 from typing import Any, List, Optional
 from typing_extensions import Annotated
 from tmi_client.models.edge_connector_one_of import EdgeConnectorOneOf
@@ -53,6 +54,20 @@ class EdgeConnector(BaseModel):
         else:
             super().__init__(**kwargs)
 
+    # Patched by regenerate_python.py: openapi-generator resolves the oneOf
+    # only inside from_dict()/from_json().  A raw dict arriving through
+    # ordinary Pydantic validation -- a constructor argument, or a parent
+    # model's model_validate() -- matched none of this wrapper's fields, so
+    # `actual_instance` stayed None and the value serialised away as null.
+    # Route those payloads through from_dict() so the union is resolved and
+    # a non-matching payload is rejected rather than silently discarded.
+    @model_validator(mode='before')
+    @classmethod
+    def _resolve_oneof_payload(cls, data: Any) -> Any:
+        if isinstance(data, dict) and data and not set(data) & set(cls.model_fields):
+            return {"actual_instance": cls.from_dict(data).actual_instance}
+        return data
+
     @field_validator('actual_instance')
     def actual_instance_must_validate_oneof(cls, v):
         instance = EdgeConnector.model_construct()
@@ -80,7 +95,7 @@ class EdgeConnector(BaseModel):
 
     @classmethod
     def from_dict(cls, obj: Union[str, Dict[str, Any]]) -> Self:
-        return cls.from_json(json.dumps(obj))
+        return cls.from_json(json.dumps(to_jsonable_python(obj)))
 
     @classmethod
     def from_json(cls, json_str: str) -> Self:

--- a/python-client-generated/v1.8.3/tmi_client/models/edge_label_position.py
+++ b/python-client-generated/v1.8.3/tmi_client/models/edge_label_position.py
@@ -16,7 +16,8 @@
 from __future__ import annotations
 import json
 import pprint
-from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt, StrictStr, ValidationError, field_validator
+from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt, StrictStr, ValidationError, field_validator, model_validator
+from pydantic_core import to_jsonable_python
 from typing import Any, List, Optional, Union
 from tmi_client.models.edge_label_position_one_of import EdgeLabelPositionOneOf
 from pydantic import StrictStr, Field
@@ -52,6 +53,20 @@ class EdgeLabelPosition(BaseModel):
         else:
             super().__init__(**kwargs)
 
+    # Patched by regenerate_python.py: openapi-generator resolves the oneOf
+    # only inside from_dict()/from_json().  A raw dict arriving through
+    # ordinary Pydantic validation -- a constructor argument, or a parent
+    # model's model_validate() -- matched none of this wrapper's fields, so
+    # `actual_instance` stayed None and the value serialised away as null.
+    # Route those payloads through from_dict() so the union is resolved and
+    # a non-matching payload is rejected rather than silently discarded.
+    @model_validator(mode='before')
+    @classmethod
+    def _resolve_oneof_payload(cls, data: Any) -> Any:
+        if isinstance(data, dict) and data and not set(data) & set(cls.model_fields):
+            return {"actual_instance": cls.from_dict(data).actual_instance}
+        return data
+
     @field_validator('actual_instance')
     def actual_instance_must_validate_oneof(cls, v):
         instance = EdgeLabelPosition.model_construct()
@@ -79,7 +94,7 @@ class EdgeLabelPosition(BaseModel):
 
     @classmethod
     def from_dict(cls, obj: Union[str, Dict[str, Any]]) -> Self:
-        return cls.from_json(json.dumps(obj))
+        return cls.from_json(json.dumps(to_jsonable_python(obj)))
 
     @classmethod
     def from_json(cls, json_str: str) -> Self:

--- a/python-client-generated/v1.8.3/tmi_client/models/edge_label_position_one_of_offset.py
+++ b/python-client-generated/v1.8.3/tmi_client/models/edge_label_position_one_of_offset.py
@@ -16,7 +16,8 @@
 from __future__ import annotations
 import json
 import pprint
-from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt, StrictStr, ValidationError, field_validator
+from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt, StrictStr, ValidationError, field_validator, model_validator
+from pydantic_core import to_jsonable_python
 from typing import Any, List, Optional, Union
 from tmi_client.models.edge_label_position_one_of_offset_one_of import EdgeLabelPositionOneOfOffsetOneOf
 from pydantic import StrictStr, Field
@@ -52,6 +53,20 @@ class EdgeLabelPositionOneOfOffset(BaseModel):
         else:
             super().__init__(**kwargs)
 
+    # Patched by regenerate_python.py: openapi-generator resolves the oneOf
+    # only inside from_dict()/from_json().  A raw dict arriving through
+    # ordinary Pydantic validation -- a constructor argument, or a parent
+    # model's model_validate() -- matched none of this wrapper's fields, so
+    # `actual_instance` stayed None and the value serialised away as null.
+    # Route those payloads through from_dict() so the union is resolved and
+    # a non-matching payload is rejected rather than silently discarded.
+    @model_validator(mode='before')
+    @classmethod
+    def _resolve_oneof_payload(cls, data: Any) -> Any:
+        if isinstance(data, dict) and data and not set(data) & set(cls.model_fields):
+            return {"actual_instance": cls.from_dict(data).actual_instance}
+        return data
+
     @field_validator('actual_instance')
     def actual_instance_must_validate_oneof(cls, v):
         instance = EdgeLabelPositionOneOfOffset.model_construct()
@@ -79,7 +94,7 @@ class EdgeLabelPositionOneOfOffset(BaseModel):
 
     @classmethod
     def from_dict(cls, obj: Union[str, Dict[str, Any]]) -> Self:
-        return cls.from_json(json.dumps(obj))
+        return cls.from_json(json.dumps(to_jsonable_python(obj)))
 
     @classmethod
     def from_json(cls, json_str: str) -> Self:

--- a/python-client-generated/v1.8.3/tmi_client/models/edge_router.py
+++ b/python-client-generated/v1.8.3/tmi_client/models/edge_router.py
@@ -16,7 +16,8 @@
 from __future__ import annotations
 import json
 import pprint
-from pydantic import BaseModel, ConfigDict, Field, StrictStr, ValidationError, field_validator
+from pydantic import BaseModel, ConfigDict, Field, StrictStr, ValidationError, field_validator, model_validator
+from pydantic_core import to_jsonable_python
 from typing import Any, List, Optional
 from typing_extensions import Annotated
 from tmi_client.models.edge_router_one_of import EdgeRouterOneOf
@@ -53,6 +54,20 @@ class EdgeRouter(BaseModel):
         else:
             super().__init__(**kwargs)
 
+    # Patched by regenerate_python.py: openapi-generator resolves the oneOf
+    # only inside from_dict()/from_json().  A raw dict arriving through
+    # ordinary Pydantic validation -- a constructor argument, or a parent
+    # model's model_validate() -- matched none of this wrapper's fields, so
+    # `actual_instance` stayed None and the value serialised away as null.
+    # Route those payloads through from_dict() so the union is resolved and
+    # a non-matching payload is rejected rather than silently discarded.
+    @model_validator(mode='before')
+    @classmethod
+    def _resolve_oneof_payload(cls, data: Any) -> Any:
+        if isinstance(data, dict) and data and not set(data) & set(cls.model_fields):
+            return {"actual_instance": cls.from_dict(data).actual_instance}
+        return data
+
     @field_validator('actual_instance')
     def actual_instance_must_validate_oneof(cls, v):
         instance = EdgeRouter.model_construct()
@@ -80,7 +95,7 @@ class EdgeRouter(BaseModel):
 
     @classmethod
     def from_dict(cls, obj: Union[str, Dict[str, Any]]) -> Self:
-        return cls.from_json(json.dumps(obj))
+        return cls.from_json(json.dumps(to_jsonable_python(obj)))
 
     @classmethod
     def from_json(cls, json_str: str) -> Self:

--- a/python-client-generated/v1.8.3/tmi_client/models/minimal_cell.py
+++ b/python-client-generated/v1.8.3/tmi_client/models/minimal_cell.py
@@ -16,7 +16,8 @@
 from __future__ import annotations
 import json
 import pprint
-from pydantic import BaseModel, ConfigDict, Field, StrictStr, ValidationError, field_validator
+from pydantic import BaseModel, ConfigDict, Field, StrictStr, ValidationError, field_validator, model_validator
+from pydantic_core import to_jsonable_python
 from typing import Any, List, Optional
 from tmi_client.models.minimal_edge import MinimalEdge
 from tmi_client.models.minimal_node import MinimalNode
@@ -56,6 +57,20 @@ class MinimalCell(BaseModel):
         else:
             super().__init__(**kwargs)
 
+    # Patched by regenerate_python.py: openapi-generator resolves the oneOf
+    # only inside from_dict()/from_json().  A raw dict arriving through
+    # ordinary Pydantic validation -- a constructor argument, or a parent
+    # model's model_validate() -- matched none of this wrapper's fields, so
+    # `actual_instance` stayed None and the value serialised away as null.
+    # Route those payloads through from_dict() so the union is resolved and
+    # a non-matching payload is rejected rather than silently discarded.
+    @model_validator(mode='before')
+    @classmethod
+    def _resolve_oneof_payload(cls, data: Any) -> Any:
+        if isinstance(data, dict) and data and not set(data) & set(cls.model_fields):
+            return {"actual_instance": cls.from_dict(data).actual_instance}
+        return data
+
     @field_validator('actual_instance')
     def actual_instance_must_validate_oneof(cls, v):
         instance = MinimalCell.model_construct()
@@ -82,7 +97,7 @@ class MinimalCell(BaseModel):
 
     @classmethod
     def from_dict(cls, obj: Union[str, Dict[str, Any]]) -> Self:
-        return cls.from_json(json.dumps(obj))
+        return cls.from_json(json.dumps(to_jsonable_python(obj)))
 
     @classmethod
     def from_json(cls, json_str: str) -> Self:

--- a/python-client-generated/v1.8.3/tmi_client/models/node_attrs_body_ref_height.py
+++ b/python-client-generated/v1.8.3/tmi_client/models/node_attrs_body_ref_height.py
@@ -16,7 +16,8 @@
 from __future__ import annotations
 import json
 import pprint
-from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt, StrictStr, ValidationError, field_validator
+from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt, StrictStr, ValidationError, field_validator, model_validator
+from pydantic_core import to_jsonable_python
 from typing import Any, List, Optional, Union
 from typing_extensions import Annotated
 from pydantic import StrictStr, Field
@@ -52,6 +53,20 @@ class NodeAttrsBodyRefHeight(BaseModel):
         else:
             super().__init__(**kwargs)
 
+    # Patched by regenerate_python.py: openapi-generator resolves the oneOf
+    # only inside from_dict()/from_json().  A raw dict arriving through
+    # ordinary Pydantic validation -- a constructor argument, or a parent
+    # model's model_validate() -- matched none of this wrapper's fields, so
+    # `actual_instance` stayed None and the value serialised away as null.
+    # Route those payloads through from_dict() so the union is resolved and
+    # a non-matching payload is rejected rather than silently discarded.
+    @model_validator(mode='before')
+    @classmethod
+    def _resolve_oneof_payload(cls, data: Any) -> Any:
+        if isinstance(data, dict) and data and not set(data) & set(cls.model_fields):
+            return {"actual_instance": cls.from_dict(data).actual_instance}
+        return data
+
     @field_validator('actual_instance')
     def actual_instance_must_validate_oneof(cls, v):
         instance = NodeAttrsBodyRefHeight.model_construct()
@@ -80,7 +95,7 @@ class NodeAttrsBodyRefHeight(BaseModel):
 
     @classmethod
     def from_dict(cls, obj: Union[str, Dict[str, Any]]) -> Self:
-        return cls.from_json(json.dumps(obj))
+        return cls.from_json(json.dumps(to_jsonable_python(obj)))
 
     @classmethod
     def from_json(cls, json_str: str) -> Self:

--- a/python-client-generated/v1.8.3/tmi_client/models/node_attrs_body_ref_width.py
+++ b/python-client-generated/v1.8.3/tmi_client/models/node_attrs_body_ref_width.py
@@ -16,7 +16,8 @@
 from __future__ import annotations
 import json
 import pprint
-from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt, StrictStr, ValidationError, field_validator
+from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt, StrictStr, ValidationError, field_validator, model_validator
+from pydantic_core import to_jsonable_python
 from typing import Any, List, Optional, Union
 from typing_extensions import Annotated
 from pydantic import StrictStr, Field
@@ -52,6 +53,20 @@ class NodeAttrsBodyRefWidth(BaseModel):
         else:
             super().__init__(**kwargs)
 
+    # Patched by regenerate_python.py: openapi-generator resolves the oneOf
+    # only inside from_dict()/from_json().  A raw dict arriving through
+    # ordinary Pydantic validation -- a constructor argument, or a parent
+    # model's model_validate() -- matched none of this wrapper's fields, so
+    # `actual_instance` stayed None and the value serialised away as null.
+    # Route those payloads through from_dict() so the union is resolved and
+    # a non-matching payload is rejected rather than silently discarded.
+    @model_validator(mode='before')
+    @classmethod
+    def _resolve_oneof_payload(cls, data: Any) -> Any:
+        if isinstance(data, dict) and data and not set(data) & set(cls.model_fields):
+            return {"actual_instance": cls.from_dict(data).actual_instance}
+        return data
+
     @field_validator('actual_instance')
     def actual_instance_must_validate_oneof(cls, v):
         instance = NodeAttrsBodyRefWidth.model_construct()
@@ -80,7 +95,7 @@ class NodeAttrsBodyRefWidth(BaseModel):
 
     @classmethod
     def from_dict(cls, obj: Union[str, Dict[str, Any]]) -> Self:
-        return cls.from_json(json.dumps(obj))
+        return cls.from_json(json.dumps(to_jsonable_python(obj)))
 
     @classmethod
     def from_json(cls, json_str: str) -> Self:

--- a/python-client-generated/v1.8.3/tmi_client/models/node_attrs_text_ref_x.py
+++ b/python-client-generated/v1.8.3/tmi_client/models/node_attrs_text_ref_x.py
@@ -16,7 +16,8 @@
 from __future__ import annotations
 import json
 import pprint
-from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt, StrictStr, ValidationError, field_validator
+from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt, StrictStr, ValidationError, field_validator, model_validator
+from pydantic_core import to_jsonable_python
 from typing import Any, List, Optional, Union
 from typing_extensions import Annotated
 from pydantic import StrictStr, Field
@@ -52,6 +53,20 @@ class NodeAttrsTextRefX(BaseModel):
         else:
             super().__init__(**kwargs)
 
+    # Patched by regenerate_python.py: openapi-generator resolves the oneOf
+    # only inside from_dict()/from_json().  A raw dict arriving through
+    # ordinary Pydantic validation -- a constructor argument, or a parent
+    # model's model_validate() -- matched none of this wrapper's fields, so
+    # `actual_instance` stayed None and the value serialised away as null.
+    # Route those payloads through from_dict() so the union is resolved and
+    # a non-matching payload is rejected rather than silently discarded.
+    @model_validator(mode='before')
+    @classmethod
+    def _resolve_oneof_payload(cls, data: Any) -> Any:
+        if isinstance(data, dict) and data and not set(data) & set(cls.model_fields):
+            return {"actual_instance": cls.from_dict(data).actual_instance}
+        return data
+
     @field_validator('actual_instance')
     def actual_instance_must_validate_oneof(cls, v):
         instance = NodeAttrsTextRefX.model_construct()
@@ -80,7 +95,7 @@ class NodeAttrsTextRefX(BaseModel):
 
     @classmethod
     def from_dict(cls, obj: Union[str, Dict[str, Any]]) -> Self:
-        return cls.from_json(json.dumps(obj))
+        return cls.from_json(json.dumps(to_jsonable_python(obj)))
 
     @classmethod
     def from_json(cls, json_str: str) -> Self:

--- a/python-client-generated/v1.8.3/tmi_client/models/node_attrs_text_ref_x2.py
+++ b/python-client-generated/v1.8.3/tmi_client/models/node_attrs_text_ref_x2.py
@@ -16,7 +16,8 @@
 from __future__ import annotations
 import json
 import pprint
-from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt, StrictStr, ValidationError, field_validator
+from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt, StrictStr, ValidationError, field_validator, model_validator
+from pydantic_core import to_jsonable_python
 from typing import Any, List, Optional, Union
 from typing_extensions import Annotated
 from pydantic import StrictStr, Field
@@ -52,6 +53,20 @@ class NodeAttrsTextRefX2(BaseModel):
         else:
             super().__init__(**kwargs)
 
+    # Patched by regenerate_python.py: openapi-generator resolves the oneOf
+    # only inside from_dict()/from_json().  A raw dict arriving through
+    # ordinary Pydantic validation -- a constructor argument, or a parent
+    # model's model_validate() -- matched none of this wrapper's fields, so
+    # `actual_instance` stayed None and the value serialised away as null.
+    # Route those payloads through from_dict() so the union is resolved and
+    # a non-matching payload is rejected rather than silently discarded.
+    @model_validator(mode='before')
+    @classmethod
+    def _resolve_oneof_payload(cls, data: Any) -> Any:
+        if isinstance(data, dict) and data and not set(data) & set(cls.model_fields):
+            return {"actual_instance": cls.from_dict(data).actual_instance}
+        return data
+
     @field_validator('actual_instance')
     def actual_instance_must_validate_oneof(cls, v):
         instance = NodeAttrsTextRefX2.model_construct()
@@ -80,7 +95,7 @@ class NodeAttrsTextRefX2(BaseModel):
 
     @classmethod
     def from_dict(cls, obj: Union[str, Dict[str, Any]]) -> Self:
-        return cls.from_json(json.dumps(obj))
+        return cls.from_json(json.dumps(to_jsonable_python(obj)))
 
     @classmethod
     def from_json(cls, json_str: str) -> Self:

--- a/python-client-generated/v1.8.3/tmi_client/models/node_attrs_text_ref_y.py
+++ b/python-client-generated/v1.8.3/tmi_client/models/node_attrs_text_ref_y.py
@@ -16,7 +16,8 @@
 from __future__ import annotations
 import json
 import pprint
-from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt, StrictStr, ValidationError, field_validator
+from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt, StrictStr, ValidationError, field_validator, model_validator
+from pydantic_core import to_jsonable_python
 from typing import Any, List, Optional, Union
 from typing_extensions import Annotated
 from pydantic import StrictStr, Field
@@ -52,6 +53,20 @@ class NodeAttrsTextRefY(BaseModel):
         else:
             super().__init__(**kwargs)
 
+    # Patched by regenerate_python.py: openapi-generator resolves the oneOf
+    # only inside from_dict()/from_json().  A raw dict arriving through
+    # ordinary Pydantic validation -- a constructor argument, or a parent
+    # model's model_validate() -- matched none of this wrapper's fields, so
+    # `actual_instance` stayed None and the value serialised away as null.
+    # Route those payloads through from_dict() so the union is resolved and
+    # a non-matching payload is rejected rather than silently discarded.
+    @model_validator(mode='before')
+    @classmethod
+    def _resolve_oneof_payload(cls, data: Any) -> Any:
+        if isinstance(data, dict) and data and not set(data) & set(cls.model_fields):
+            return {"actual_instance": cls.from_dict(data).actual_instance}
+        return data
+
     @field_validator('actual_instance')
     def actual_instance_must_validate_oneof(cls, v):
         instance = NodeAttrsTextRefY.model_construct()
@@ -80,7 +95,7 @@ class NodeAttrsTextRefY(BaseModel):
 
     @classmethod
     def from_dict(cls, obj: Union[str, Dict[str, Any]]) -> Self:
-        return cls.from_json(json.dumps(obj))
+        return cls.from_json(json.dumps(to_jsonable_python(obj)))
 
     @classmethod
     def from_json(cls, json_str: str) -> Self:

--- a/python-client-generated/v1.8.3/tmi_client/models/node_attrs_text_ref_y2.py
+++ b/python-client-generated/v1.8.3/tmi_client/models/node_attrs_text_ref_y2.py
@@ -16,7 +16,8 @@
 from __future__ import annotations
 import json
 import pprint
-from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt, StrictStr, ValidationError, field_validator
+from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt, StrictStr, ValidationError, field_validator, model_validator
+from pydantic_core import to_jsonable_python
 from typing import Any, List, Optional, Union
 from typing_extensions import Annotated
 from pydantic import StrictStr, Field
@@ -52,6 +53,20 @@ class NodeAttrsTextRefY2(BaseModel):
         else:
             super().__init__(**kwargs)
 
+    # Patched by regenerate_python.py: openapi-generator resolves the oneOf
+    # only inside from_dict()/from_json().  A raw dict arriving through
+    # ordinary Pydantic validation -- a constructor argument, or a parent
+    # model's model_validate() -- matched none of this wrapper's fields, so
+    # `actual_instance` stayed None and the value serialised away as null.
+    # Route those payloads through from_dict() so the union is resolved and
+    # a non-matching payload is rejected rather than silently discarded.
+    @model_validator(mode='before')
+    @classmethod
+    def _resolve_oneof_payload(cls, data: Any) -> Any:
+        if isinstance(data, dict) and data and not set(data) & set(cls.model_fields):
+            return {"actual_instance": cls.from_dict(data).actual_instance}
+        return data
+
     @field_validator('actual_instance')
     def actual_instance_must_validate_oneof(cls, v):
         instance = NodeAttrsTextRefY2.model_construct()
@@ -80,7 +95,7 @@ class NodeAttrsTextRefY2(BaseModel):
 
     @classmethod
     def from_dict(cls, obj: Union[str, Dict[str, Any]]) -> Self:
-        return cls.from_json(json.dumps(obj))
+        return cls.from_json(json.dumps(to_jsonable_python(obj)))
 
     @classmethod
     def from_json(cls, json_str: str) -> Self:

--- a/regenerate_python.py
+++ b/regenerate_python.py
@@ -319,6 +319,204 @@ def patch_oneof_return_types(client_dir: Path, had_issues: bool) -> bool:
     return had_issues
 
 
+def _oneof_wrapper_files(client_dir: Path) -> list[Path]:
+    """Return the generated ``oneOf`` wrapper models (those with an
+    ``actual_instance`` field holding the resolved variant)."""
+    models_dir = client_dir / "tmi_client" / "models"
+    if not models_dir.is_dir():
+        return []
+    return [
+        f
+        for f in sorted(models_dir.glob("*.py"))
+        if "actual_instance: Optional[" in f.read_text(encoding="utf-8")
+    ]
+
+
+# Inserted into every oneOf wrapper immediately before its
+# `actual_instance` field validator.
+ONEOF_COERCION_VALIDATOR = '''    # Patched by regenerate_python.py: openapi-generator resolves the oneOf
+    # only inside from_dict()/from_json().  A raw dict arriving through
+    # ordinary Pydantic validation -- a constructor argument, or a parent
+    # model's model_validate() -- matched none of this wrapper's fields, so
+    # `actual_instance` stayed None and the value serialised away as null.
+    # Route those payloads through from_dict() so the union is resolved and
+    # a non-matching payload is rejected rather than silently discarded.
+    @model_validator(mode='before')
+    @classmethod
+    def _resolve_oneof_payload(cls, data: Any) -> Any:
+        if isinstance(data, dict) and data and not set(data) & set(cls.model_fields):
+            return {"actual_instance": cls.from_dict(data).actual_instance}
+        return data
+
+'''
+
+
+def patch_oneof_constructor_coercion(client_dir: Path, had_issues: bool) -> bool:
+    """Make ``oneOf`` wrappers resolve raw dicts during normal validation.
+
+    openapi-generator only resolves a ``oneOf`` union inside the wrapper's
+    ``from_dict()``/``from_json()``.  Passing raw dicts anywhere Pydantic
+    validates them instead — ``DfdDiagramInput(cells=[{...}])``, or any
+    ``model_validate()`` on a parent model — matched no field on the wrapper,
+    left ``actual_instance`` as ``None``, and serialised the request body as
+    ``"cells": [null, null]``, silently discarding every cell.  Invalid cells
+    were accepted the same way.
+
+    The fix adds a ``mode='before'`` model validator that recognises a payload
+    dict (one sharing no key with the wrapper's own fields) and routes it
+    through ``from_dict()``.  Wrapper-shaped input and non-dict input are
+    passed through untouched.
+    """
+    patched_count = 0
+
+    for model_file in _oneof_wrapper_files(client_dir):
+        content = model_file.read_text(encoding="utf-8")
+        if "_resolve_oneof_payload" in content:
+            continue
+
+        anchor = "    @field_validator('actual_instance')\n"
+        if anchor not in content:
+            print_warning(
+                f"OneOf coercion patch: no anchor in {model_file.name} — skipped"
+            )
+            had_issues = True
+            continue
+
+        new_content = content.replace(anchor, ONEOF_COERCION_VALIDATOR + anchor, 1)
+
+        # `model_validator` and `Any` must be importable in the module.
+        new_content = re.sub(
+            r"^(from pydantic import .*?)(\n)",
+            lambda m: (
+                m.group(1) + ", model_validator" + m.group(2)
+                if "model_validator" not in m.group(1)
+                else m.group(0)
+            ),
+            new_content,
+            count=1,
+            flags=re.MULTILINE,
+        )
+        if not re.search(r"^from typing import .*\bAny\b", new_content, re.MULTILINE):
+            new_content = re.sub(
+                r"^(from typing import )",
+                r"\1Any, ",
+                new_content,
+                count=1,
+                flags=re.MULTILINE,
+            )
+
+        model_file.write_text(new_content, encoding="utf-8")
+        patched_count += 1
+
+    if patched_count > 0:
+        print_success(f"OneOf coercion patch: {patched_count} wrappers fixed")
+    else:
+        print_warning("OneOf coercion patch: no wrappers needed fixing")
+
+    return had_issues
+
+
+def patch_oneof_json_safety(client_dir: Path, had_issues: bool) -> bool:
+    """Let ``oneOf`` wrappers accept ``to_dict()`` output.
+
+    The generated ``from_dict`` re-serialises its argument with
+    ``json.dumps(obj)`` before handing it to ``from_json``.  ``to_dict()``
+    leaves native ``UUID`` and ``datetime`` objects in place, so feeding a
+    model's own output back in raised ``TypeError: Object of type UUID is not
+    JSON serializable`` — the round trip a read-modify-write flow needs.
+
+    ``to_jsonable_python`` is what the generator already uses in ``to_json``
+    for exactly this reason; this applies it on the way back in.
+    """
+    patched_count = 0
+    old_call = "return cls.from_json(json.dumps(obj))"
+    new_call = "return cls.from_json(json.dumps(to_jsonable_python(obj)))"
+
+    for model_file in _oneof_wrapper_files(client_dir):
+        content = model_file.read_text(encoding="utf-8")
+        if old_call not in content:
+            continue
+
+        new_content = content.replace(old_call, new_call)
+        if "from pydantic_core import to_jsonable_python" not in new_content:
+            new_content = re.sub(
+                r"^(from pydantic import .*\n)",
+                r"\1from pydantic_core import to_jsonable_python\n",
+                new_content,
+                count=1,
+                flags=re.MULTILINE,
+            )
+
+        model_file.write_text(new_content, encoding="utf-8")
+        patched_count += 1
+
+    if patched_count > 0:
+        print_success(f"OneOf JSON-safety patch: {patched_count} wrappers fixed")
+    else:
+        print_warning("OneOf JSON-safety patch: no wrappers needed fixing")
+
+    return had_issues
+
+
+def patch_self_referential_discriminator(client_dir: Path, had_issues: bool) -> bool:
+    """Stop ``from_dict`` recursing when a discriminator maps a class to itself.
+
+    When a schema is both a discriminator parent and one of its own mapping
+    targets, openapi-generator emits a ``from_dict`` that is *only* a dispatch
+    table — and one of its branches dispatches straight back into the same
+    class.  ``DfdDiagram`` maps ``'DFD-1.0.0'`` to ``'DfdDiagram'``, so
+    ``DfdDiagram.from_dict()`` recursed until it raised ``RecursionError``.
+    ``ApiClient.__deserialize_model`` deserialises 200 responses through
+    ``klass.from_dict()``, so every DFD diagram read failed.
+
+    The fix replaces the self-dispatching branch with direct validation.
+    Nested models — including ``oneOf`` wrappers, once
+    ``patch_oneof_constructor_coercion`` has run — are resolved by Pydantic.
+    """
+    models_dir = client_dir / "tmi_client" / "models"
+    if not models_dir.is_dir():
+        print_warning("Models directory not found — skipping discriminator patch")
+        return True
+
+    patched_count = 0
+    for model_file in sorted(models_dir.glob("*.py")):
+        content = model_file.read_text(encoding="utf-8")
+        if "return import_module" not in content:
+            continue
+
+        class_match = re.search(r"^class (\w+)\(", content, re.MULTILINE)
+        if not class_match:
+            continue
+        cls_name = class_match.group(1)
+
+        # Only the branch that dispatches back into this very class.
+        self_branch = re.compile(
+            rf"(^        if object_type ==\s+'[^']+':\n)"
+            rf"            return import_module\([^)]*\)\.{cls_name}\.from_dict\(obj\)\n",
+            re.MULTILINE,
+        )
+        replacement = (
+            r"\1"
+            "            # Patched by regenerate_python.py: the discriminator maps this\n"
+            "            # value back to this same class, so dispatching would recurse\n"
+            "            # forever.  Validate directly instead.\n"
+            "            return cls.model_validate(obj)\n"
+        )
+        new_content, count = self_branch.subn(replacement, content)
+        if count:
+            model_file.write_text(new_content, encoding="utf-8")
+            patched_count += count
+
+    if patched_count > 0:
+        print_success(
+            f"Self-discriminator patch: {patched_count} recursive branches fixed"
+        )
+    else:
+        print_warning("Self-discriminator patch: no branches needed fixing")
+
+    return had_issues
+
+
 def patch_api_client_types(client_dir: Path, had_issues: bool) -> bool:
     """Fix type annotation issues in the generated api_client.py.
 
@@ -524,6 +722,9 @@ def main(spec_path: str, output_dir: str | None = None) -> int:
     had_issues = patch_urllib3_minimum_version(client_dir, had_issues)
     had_issues = patch_python_minimum_version(client_dir, had_issues)
     had_issues = patch_oneof_return_types(client_dir, had_issues)
+    had_issues = patch_oneof_constructor_coercion(client_dir, had_issues)
+    had_issues = patch_oneof_json_safety(client_dir, had_issues)
+    had_issues = patch_self_referential_discriminator(client_dir, had_issues)
     had_issues = patch_api_client_types(client_dir, had_issues)
     had_issues = patch_configuration_self_type(client_dir, had_issues)
     print_success("Patches applied")
@@ -612,6 +813,15 @@ def main(spec_path: str, output_dir: str | None = None) -> int:
             "(CVE fixes for decompression-bomb and redirect vulnerabilities)\n"
             "- OneOf model return-type fix (type checkers can't narrow "
             "through hasattr guards on actual_instance)\n"
+            "- OneOf constructor coercion (openapi-generator bug: raw dicts "
+            "reaching Pydantic validation didn't resolve the oneOf, leaving "
+            "actual_instance None and serialising the value away as null)\n"
+            "- OneOf JSON-safety fix (openapi-generator bug: from_dict() did "
+            "json.dumps() on to_dict() output, which still holds native UUID "
+            "and datetime objects, breaking the read-modify-write round trip)\n"
+            "- Self-referential discriminator fix (openapi-generator bug: a "
+            "class listed in its own discriminator mapping dispatched from_dict() "
+            "back into itself, so every DFD diagram read raised RecursionError)\n"
             "- API client type annotation fix (None guards, str coercion, "
             "return-type suppression)\n"
             "- Configuration Self type fix (ClassVar[Optional[Self]] causes "


### PR DESCRIPTION
Fixes #41.

All three defects are openapi-generator codegen bugs, so they are fixed as patches in `regenerate_python.py` and re-applied on every regeneration — not hand-edits to generated files.

| # | Defect | Patch |
|---|---|---|
| 1 | Raw dict `cells` reaching Pydantic validation didn't resolve the `oneOf`; `actual_instance` stayed `None` and the body serialised as `"cells": [null, null]`, silently discarding every cell and accepting invalid ones | `patch_oneof_constructor_coercion` |
| 2 | `from_dict()` did `json.dumps()` on `to_dict()` output, which still holds native `UUID`/`datetime` → `Object of type UUID is not JSON serializable` | `patch_oneof_json_safety` |
| 3 | `DfdDiagram` maps `'DFD-1.0.0'` to itself, so its dispatch-only `from_dict()` recursed forever — **every** DFD diagram read raised `RecursionError` | `patch_self_referential_discriminator` |

Defect 3 was the high-priority one: `ApiClient` deserialises 200 responses via `klass.from_dict()`, so `get_threat_model_diagram()` did not work at all.

### How they were fixed

1. A `mode='before'` model validator on each `oneOf` wrapper routes payload dicts (those sharing no key with the wrapper's own fields) through `from_dict()`. Wrapper-shaped and non-dict input pass through untouched.
2. `from_dict()` now serialises via `to_jsonable_python`, which the generator already uses in `to_json()` for the same reason.
3. The branch that dispatches a class back into itself now calls `cls.model_validate(obj)`. Nested models — including the `oneOf` wrappers, once patch 1 has run — are resolved by Pydantic.

### Verification

Both `v1.3.0` and `v1.8.3` were **regenerated from their specs**, so the committed clients are exactly what regeneration produces, not a hand-applied approximation.

- `test_diagram_fixes.py` gains five checks: one per defect, plus a guard that the constructor still rejects a cell matching neither `oneOf` branch, plus the read-modify-write round trip. Each was watched failing (`RecursionError`, `TypeError: Object of type UUID…`, `oneOf resolved to ['NoneType', 'NoneType']`) before the patches were written. **14/14 pass** in both versions.
- Unit tests: **502 passed** (v1.3.0), **628 passed** (v1.8.3).
- `ty check tmi_client/`: 12 and 24 diagnostics — **identical to the pre-change baseline**, so no new type-checker findings.
- `ApiClient().deserialize(...)` against a realistic 200 payload returns a `DfdDiagram` with cells resolving to `['Node', 'Edge']`.

The now-obsolete `KNOWN DEFECTS` note is removed from `test_diagram_fixes.py`, and CLAUDE.md drops the three warnings and records where the fixes live.

README `Build date:` churn from regeneration was reverted, per the convention from #42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116ox2SywZRuZ46c8VEWDHh