### PR TITLE
ci: add a TestPyPI-only dispatch path for the Python publish workflow

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -5,13 +5,21 @@ on:
     types: [published]
   # Manual dry run: builds and tests a committed client version without
   # publishing anything, so action-version bumps in this file can be validated
-  # without cutting a release. The publish jobs below stay gated on `release`.
+  # without cutting a release. `publish_testpypi` extends that to a real
+  # TestPyPI upload — the one step a dry run cannot otherwise reach, since
+  # gh-action-pypi-publish is only exercised by an actual upload. PyPI itself
+  # stays gated on `release` regardless.
   workflow_dispatch:
     inputs:
       version:
-        description: "Client version directory to build, e.g. 1.8.3 (dry run — does not publish)"
+        description: "Client version directory to build, e.g. 1.8.3"
         required: true
         type: string
+      publish_testpypi:
+        description: "Publish to TestPyPI under a throwaway .devN version (never touches PyPI)"
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   build-and-test:
@@ -84,6 +92,37 @@ jobs:
           fi
           exit "$code"
 
+      # Only for a TestPyPI dispatch. TestPyPI rejects a re-upload of a version
+      # it already has ("file already exists"), so a repeatable test needs a
+      # version nobody will ever claim. run_number makes each dispatch unique,
+      # and a PEP 440 .devN suffix keeps the real version numbers free. This
+      # runs *after* the version-match check and the tests, so both still see
+      # the committed version.
+      - name: Stamp a throwaway dev version for TestPyPI
+        if: inputs.publish_testpypi
+        working-directory: ${{ steps.version.outputs.pkg_dir }}
+        env:
+          BASE_VERSION: ${{ steps.version.outputs.tag_version }}
+          RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          DEV_VERSION="${BASE_VERSION}.dev${RUN_NUMBER}"
+          echo "Building throwaway version $DEV_VERSION for TestPyPI"
+          python - "$DEV_VERSION" <<'PY'
+          import pathlib, re, sys
+          dev = sys.argv[1]
+          for path, pattern, repl in (
+              ("pyproject.toml", r'^version = ".*"', f'version = "{dev}"'),
+              ("setup.py", r'^VERSION = ".*"', f'VERSION = "{dev}"'),
+          ):
+              p = pathlib.Path(path)
+              text = p.read_text()
+              new, count = re.subn(pattern, repl, text, count=1, flags=re.MULTILINE)
+              if count != 1:
+                  raise SystemExit(f"::error::no version line matched in {path}")
+              p.write_text(new)
+              print(f"stamped {path}")
+          PY
+
       - name: Build package
         working-directory: ${{ steps.version.outputs.pkg_dir }}
         run: python -m build
@@ -96,8 +135,9 @@ jobs:
 
   publish-testpypi:
     needs: build-and-test
-    # Never publish from a manual dry run.
-    if: github.event_name == 'release'
+    # A release always publishes. A manual dispatch publishes only when
+    # explicitly asked, and then only the throwaway .devN build stamped above.
+    if: github.event_name == 'release' || inputs.publish_testpypi
     runs-on: ubuntu-latest
     environment: testpypi
     permissions:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -91,6 +91,33 @@ When you publish a GitHub release with a `v*` tag:
 
 Each workflow runs tests before publishing. If tests fail, publishing is skipped.
 
+## Validating the Publish Workflows Without a Release
+
+Each publish workflow accepts a `workflow_dispatch` that builds and tests a
+committed client version without publishing, so action-version bumps can be
+validated without cutting a release:
+
+```bash
+gh workflow run publish-python.yml -f version=1.8.3
+gh workflow run publish-js.yml     -f version=1.8.3
+gh workflow run publish-go.yml     -f version=1.8.3   # dotted, not underscored
+```
+
+A dry run cannot reach `gh-action-pypi-publish` itself — that action only does
+anything on a real upload. To exercise it, dispatch the Python workflow with
+`publish_testpypi=true`:
+
+```bash
+gh workflow run publish-python.yml -f version=1.8.3 -f publish_testpypi=true
+```
+
+That stamps a throwaway `<version>.dev<run_number>` into `pyproject.toml` and
+`setup.py` **after** the version-match check and the tests, then uploads to
+TestPyPI only. `publish-pypi` stays gated on `release` and is skipped. The
+`.devN` suffix matters because TestPyPI rejects a re-upload of a version it
+already holds ("file already exists"), and it keeps the real version numbers
+unclaimed. These uploads are throwaway; nothing consumes them.
+
 ## Package Installation (for consumers)
 
 ```bash


### PR DESCRIPTION
Closes the last open item from the previous session: `gh-action-pypi-publish` v1.14.2 was still unexercised, because a dry run validates everything in `publish-python.yml` *except* the publish action itself — that action only does anything on a real upload. Its first execution was therefore going to be a real publish to PyPI.

### What this adds

A `publish_testpypi` boolean input on the existing `workflow_dispatch`:

```bash
gh workflow run publish-python.yml -f version=1.8.3 -f publish_testpypi=true
```

- Stamps a throwaway `<version>.dev<run_number>` into `pyproject.toml` and `setup.py`, then uploads to **TestPyPI only**.
- Stamping runs **after** the version-match check and the tests, so both still see the committed version.
- `publish-pypi` remains gated on `github.event_name == 'release'`, so a dispatch skips it. PyPI is untouched.

The `.devN` suffix is what makes this repeatable — TestPyPI rejects a re-upload of a version it already holds ("file already exists") — and it leaves the real version numbers unclaimed. `run_number` keeps each dispatch distinct.

### Verification

- The stamping step's `run` block was extracted from the parsed YAML and checked with `bash -n` (exit 0); the heredoc de-indents correctly.
- The stamping script was run against real copies of v1.8.3's `pyproject.toml` and `setup.py` — both stamped to `1.8.3.dev999`. It fails loudly (`::error::`) if a version line does not match, rather than silently building the wrong version.
- `actionlint` reports nothing new; the only findings across `.github/workflows/` remain the four pre-existing info-level `SC2012`s in `ci.yml` and `security-audit.yml`.
- Untrusted-ish inputs go through `env:` rather than `${{ }}` interpolation, matching the existing steps.

`RELEASING.md` gains a section documenting the dry-run dispatch for all three workflows plus this TestPyPI path. (It also corrects the Go dispatch, which takes a dotted version, not the underscored directory name.)

Once merged I'll dispatch it against `main` to actually exercise the action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116ox2SywZRuZ46c8VEWDHh